### PR TITLE
Add extension info for loading/saving.

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -318,7 +318,7 @@ function _saveModel(fname,backup,autosave)
 			var options = {'extensions':['\\.model'],
 						   'multipleChoice':false,
 						   'manualInput':true,
-						   'title':'specify target model',
+						   'title':'specify target model\nextension: .model',
 						   'startDir':'model'},
 				callback =
 					function(fnames)

--- a/users/(default)/Toolbars/CompileMenu/CompileMenu.buttons.model
+++ b/users/(default)/Toolbars/CompileMenu/CompileMenu.buttons.model
@@ -545,7 +545,9 @@
 		"edges": [],
 		"metamodels": [
 			"/Formalisms/__LanguageSyntax__/ConcreteSyntax/ConcreteSyntax.defaultIcons",
-			"/Formalisms/__Utilities__/Buttons/Buttons.defaultIcons"
+			"/Formalisms/__Utilities__/Buttons/Buttons.defaultIcons",
+			"/Formalisms/__LanguageSyntax__/SimpleClassDiagram/SimpleClassDiagram.defaultIcons",
+			"/Formalisms/SCCD/SCCD.defaultIcons"
 		]
 	},
 	"asm": {
@@ -561,7 +563,7 @@
 				},
 				"code": {
 					"type": "code",
-					"value": "var \toptions = {'extensions':['\\\\..*Icons.metamodel'],\n\t\t   'multipleChoice':false,\n\t\t   'manualInput':true,\n                   'title':'specify target icon definition metamodel',\n                   'startDir':'model'},            \n\tcallback = \tfunction(fnames)\n\t\t\t{\n\t\t\t\tCompileUtils.compileToCSMM(fnames[0]);\n\t\t\t};\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t WindowManagement.openDialog(_FILE_BROWSER,options,callback);"
+					"value": "var \textension = 'Icons.metamodel',\n                    options = {'extensions':['\\\\..*' + extension],\n\t\t   'multipleChoice':false,\n\t\t   'manualInput':true,\n                   'title':'specify target icon definition metamodel\\nextension: ' + extension + '\\nexample: TrafficLight.defaultIcons.metamodel',\n                   'startDir':'model'},            \n\tcallback = \tfunction(fnames)\n\t\t\t{\n\t\t\t\tCompileUtils.compileToCSMM(fnames[0]);\n\t\t\t};\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t WindowManagement.openDialog(_FILE_BROWSER,options,callback);"
 				},
 				"$type": "/Formalisms/__Utilities__/Buttons/Buttons/Button"
 			},
@@ -576,7 +578,7 @@
 				},
 				"code": {
 					"type": "code",
-					"value": "var \toptions = {'extensions':['\\\\.metamodel'],\n\t\t   'multipleChoice':false,\n\t\t   'manualInput':true,\n                   'title':'specify target abstract syntax metamodel',\n                   'startDir':'model'},\n\tcallback = \tfunction(fnames)\n\t\t\t{\n\t\t\t\tCompileUtils.compileToASMM(fnames[0]);\n\t\t\t};\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t WindowManagement.openDialog(_FILE_BROWSER,options,callback);"
+					"value": "var \textension = '.metamodel',\n                    options = {'extensions':['\\\\' + extension],\n\t\t   'multipleChoice':false,\n\t\t   'manualInput':true,\n                   'title':'specify target abstract syntax metamodel\\nextension: ' + extension + '\\nexample: TrafficLight.metamodel',\n                   'startDir':'model'},\n\tcallback = \tfunction(fnames)\n\t\t\t{\n\t\t\t\tCompileUtils.compileToASMM(fnames[0]);\n\t\t\t};\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t WindowManagement.openDialog(_FILE_BROWSER,options,callback);"
 				},
 				"$type": "/Formalisms/__Utilities__/Buttons/Buttons/Button"
 			},
@@ -591,7 +593,7 @@
 				},
 				"code": {
 					"type": "code",
-					"value": "var \toptions = {'extensions':['\\\\.metamodel'],\n\t\t   'multipleChoice':false,\n\t\t   'manualInput':true,\n                   'title':'choose Abstract Syntax metamodel to compile',\n                   'startDir':'model'},\n\tcallback = \tfunction(fnames)\n\t\t\t{\n\t\t\t\tCompileUtils.compileToPatternMM(fnames[0]);\n\t\t\t};\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t WindowManagement.openDialog(_FILE_BROWSER,options,callback);"
+					"value": "var \textension = '.metamodel',\n                options = {'extensions':['\\\\' + extension],\n\t\t   'multipleChoice':false,\n\t\t   'manualInput':true,\n                   'title':'choose Abstract Syntax metamodel to compile\\nextension: ' + extension +'\\nexample:TrafficLight.metamodel',\n                   'startDir':'model'},\n\tcallback = \tfunction(fnames)\n\t\t\t{\n\t\t\t\tCompileUtils.compileToPatternMM(fnames[0]);\n\t\t\t};\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t WindowManagement.openDialog(_FILE_BROWSER,options,callback);"
 				},
 				"$type": "/Formalisms/__Utilities__/Buttons/Buttons/Button"
 			}
@@ -599,7 +601,9 @@
 		"edges": [],
 		"metamodels": [
 			"/Formalisms/__LanguageSyntax__/ConcreteSyntax/ConcreteSyntax",
-			"/Formalisms/__Utilities__/Buttons/Buttons"
+			"/Formalisms/__Utilities__/Buttons/Buttons",
+			"/Formalisms/__LanguageSyntax__/SimpleClassDiagram/SimpleClassDiagram",
+			"/Formalisms/SCCD/SCCD"
 		]
 	}
 }

--- a/users/(default)/Toolbars/MainMenu/MainMenu.buttons.model
+++ b/users/(default)/Toolbars/MainMenu/MainMenu.buttons.model
@@ -2704,7 +2704,10 @@
 		},
 		"edges": [],
 		"metamodels": [
-			"/Formalisms/__Utilities__/Buttons/Buttons.defaultIcons"
+			"/Formalisms/__Utilities__/Buttons/Buttons.defaultIcons",
+			"/Formalisms/__LanguageSyntax__/ConcreteSyntax/ConcreteSyntax.defaultIcons",
+			"/Formalisms/__LanguageSyntax__/SimpleClassDiagram/SimpleClassDiagram.defaultIcons",
+			"/Formalisms/SCCD/SCCD.defaultIcons"
 		]
 	},
 	"asm": {
@@ -2720,7 +2723,7 @@
 				},
 				"code": {
 					"type": "code",
-					"value": "var options  = {'extensions':['.*Icons.metamodel','.*Icons.pattern.metamodel','buttons.model'],\n            \t'multipleChoice':true,\n                'title':'choose toolbar(s) to load',\n                'startDir':'toolbar' },\n    callback = \tfunction(fnames)\n\t\t{\n\t\t   fnames.forEach( function(fname) {_loadToolbar(fname);} );\n\t\t};\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
+					"value": "var options  = {'extensions':['.*Icons.metamodel','.*Icons.pattern.metamodel','buttons.model'],\n            \t'multipleChoice':true,\n                'title':'choose toolbar(s) to load\\nextensions: Icons.metamodel, Icons.pattern.metamodel, buttons.model',\n                'startDir':'toolbar' },\n    callback = \tfunction(fnames)\n\t\t{\n\t\t   fnames.forEach( function(fname) {_loadToolbar(fname);} );\n\t\t};\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
 				},
 				"$type": "/Formalisms/__Utilities__/Buttons/Buttons/Button"
 			},
@@ -2750,7 +2753,7 @@
 				},
 				"code": {
 					"type": "code",
-					"value": "var options = {'extensions':['\\\\.model'],\n\t       'multipleChoice':false,\n               'title':'choose model to load',\n               'startDir':'model'},\n    callback = \n        function(fnames)\n        {                    \n            if( fnames.length > 0 )\n                _loadModel(fnames[0]);\n        };\n\nfunction doIt() {\n    WindowManagement.openDialog(_FILE_BROWSER,options,callback);\n}\n\n\nif (! __isSaved() ) {\n\tGUIUtils.setupAndShowDialog(\n\t\t[GUIUtils.getTextSpan('There are unsaved changes. Are you sure you want to continue?')],\n\t\tundefined,\n\t\t__TWO_BUTTONS,\n\t\t'Unsaved Changes',\n\t\tdoIt);\n} else {\n    doIt();\n}"
+					"value": "var options = {'extensions':['\\\\.model'],\n\t       'multipleChoice':false,\n               'title':'choose model to load\\nextension: .model',\n               'startDir':'model'},\n    callback = \n        function(fnames)\n        {                    \n            if( fnames.length > 0 )\n                _loadModel(fnames[0]);\n        };\n\nfunction doIt() {\n    WindowManagement.openDialog(_FILE_BROWSER,options,callback);\n}\n\n\nif (! __isSaved() ) {\n\tGUIUtils.setupAndShowDialog(\n\t\t[GUIUtils.getTextSpan('There are unsaved changes. Are you sure you want to continue?')],\n\t\tundefined,\n\t\t__TWO_BUTTONS,\n\t\t'Unsaved Changes',\n\t\tdoIt);\n} else {\n    doIt();\n}"
 				},
 				"$type": "/Formalisms/__Utilities__/Buttons/Buttons/Button"
 			},
@@ -2780,7 +2783,7 @@
 				},
 				"code": {
 					"type": "code",
-					"value": "var options = {'extensions':['\\\\.model'],\n\t       'multipleChoice':false,\n\t       'manualInput':true,\n               'title':'specify target model',\n               'startDir':'model'},\n    callback =\n\tfunction(fnames)\n\t{\n\t\t_saveModel(fnames[0]);\n\t};\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
+					"value": "var options = {'extensions':['\\\\.model'],\n\t       'multipleChoice':false,\n\t       'manualInput':true,\n               'title':'specify target model\\nextension: .model',\n               'startDir':'model'},\n    callback =\n\tfunction(fnames)\n\t{\n\t\t_saveModel(fnames[0]);\n\t};\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
 				},
 				"$type": "/Formalisms/__Utilities__/Buttons/Buttons/Button"
 			},
@@ -2900,7 +2903,7 @@
 				},
 				"code": {
 					"type": "code",
-					"value": "var options = {'extensions':['\\\\.model'],\n\t       'multipleChoice':false,\n               'title':'choose model to insert',\n               'startDir':'model'},\n    callback = \n\tfunction(fnames)\n\t{\n\t   _insertModel(fnames[0]);\n\t};\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
+					"value": "var options = {'extensions':['\\\\.model'],\n\t       'multipleChoice':false,\n               'title':'choose model to insert\\nextension: .model',\n               'startDir':'model'},\n    callback = \n\tfunction(fnames)\n\t{\n\t   _insertModel(fnames[0]);\n\t};\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
 				},
 				"$type": "/Formalisms/__Utilities__/Buttons/Buttons/Button"
 			},
@@ -2937,7 +2940,10 @@
 		},
 		"edges": [],
 		"metamodels": [
-			"/Formalisms/__Utilities__/Buttons/Buttons"
+			"/Formalisms/__Utilities__/Buttons/Buttons",
+			"/Formalisms/__LanguageSyntax__/ConcreteSyntax/ConcreteSyntax",
+			"/Formalisms/__LanguageSyntax__/SimpleClassDiagram/SimpleClassDiagram",
+			"/Formalisms/SCCD/SCCD"
 		]
 	}
 }

--- a/users/(default)/Toolbars/TransformationController/TransformationController.buttons.model
+++ b/users/(default)/Toolbars/TransformationController/TransformationController.buttons.model
@@ -1084,7 +1084,10 @@
 		},
 		"edges": [],
 		"metamodels": [
-			"/Formalisms/__Utilities__/Buttons/Buttons.defaultIcons"
+			"/Formalisms/__Utilities__/Buttons/Buttons.defaultIcons",
+			"/Formalisms/__LanguageSyntax__/ConcreteSyntax/ConcreteSyntax.defaultIcons",
+			"/Formalisms/__LanguageSyntax__/SimpleClassDiagram/SimpleClassDiagram.defaultIcons",
+			"/Formalisms/SCCD/SCCD.defaultIcons"
 		]
 	},
 	"asm": {
@@ -1100,7 +1103,7 @@
 				},
 				"code": {
 					"type": "code",
-					"value": "var options  = {'extensions':['T_.*\\\\.model'],\n                'multipleChoice':true,\n                'title':'choose transformation model to run',\n                'startDir':'transformation'},\n    callback = function(fnames)\n               {\n                    _httpReq(\n                        'PUT',\n                        '/__mt/current.transform?wid='+_context.wid,\n                        {'transfs':fnames,\n                         'username':_context.username});\n               };\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
+					"value": "var options  = {'extensions':['T_.*\\\\.model'],\n                'multipleChoice':true,\n                'title':'choose transformation model to run\\nexample:T_transformToSC.model',\n                'startDir':'transformation'},\n    callback = function(fnames)\n               {\n                    _httpReq(\n                        'PUT',\n                        '/__mt/current.transform?wid='+_context.wid,\n                        {'transfs':fnames,\n                         'username':_context.username});\n               };\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
 				},
 				"$type": "/Formalisms/__Utilities__/Buttons/Buttons/Button"
 			},
@@ -1182,7 +1185,10 @@
 		},
 		"edges": [],
 		"metamodels": [
-			"/Formalisms/__Utilities__/Buttons/Buttons"
+			"/Formalisms/__Utilities__/Buttons/Buttons",
+			"/Formalisms/__LanguageSyntax__/ConcreteSyntax/ConcreteSyntax",
+			"/Formalisms/__LanguageSyntax__/SimpleClassDiagram/SimpleClassDiagram",
+			"/Formalisms/SCCD/SCCD"
 		]
 	}
 }

--- a/users/(default)/Toolbars/TransformationEditor/TransformationEditor.buttons.model
+++ b/users/(default)/Toolbars/TransformationEditor/TransformationEditor.buttons.model
@@ -904,7 +904,9 @@
 		},
 		"edges": [],
 		"metamodels": [
-			"/Formalisms/__Utilities__/Buttons/Buttons.defaultIcons"
+			"/Formalisms/__Utilities__/Buttons/Buttons.defaultIcons",
+			"/Formalisms/__LanguageSyntax__/ConcreteSyntax/ConcreteSyntax.defaultIcons",
+			"/Formalisms/__LanguageSyntax__/SimpleClassDiagram/SimpleClassDiagram.defaultIcons"
 		]
 	},
 	"asm": {
@@ -920,7 +922,7 @@
 				},
 				"code": {
 					"type": "code",
-					"value": "var options  = {'extensions':['R_.*\\\\.model'],\n                'multipleChoice':false,\n                'title':'choose rule model to load',\n                'startDir':'transformation'},\n    callback =  function(fnames)\n                {\n                    _loadModel(fnames[0]);\n                };\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
+					"value": "var options  = {'extensions':['R_.*\\\\.model'],\n                'multipleChoice':false,\n                'title':'choose rule model to load\\nexample: R_TimedTransition.model',\n                'startDir':'transformation'},\n    callback =  function(fnames)\n                {\n                    _loadModel(fnames[0]);\n                };\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
 				},
 				"$type": "/Formalisms/__Utilities__/Buttons/Buttons/Button"
 			},
@@ -935,7 +937,7 @@
 				},
 				"code": {
 					"type": "code",
-					"value": "var options  = {'extensions':['\\\\..*Icons\\\\.pattern\\\\.metamodel'],\n                'multipleChoice':true,\n                'title':'choose pattern metamodel to load',\n                'startDir':'transformation'},\n    callback = function(fnames)\n               {\n                    fnames.forEach( function(fname) {_loadToolbar(fname);} );\n               };\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
+					"value": "var options  = {'extensions':['\\\\..*Icons\\\\.pattern\\\\.metamodel'],\n                'multipleChoice':true,\n                'title':'choose pattern metamodel to load\\nexample: TrafficLight.defaultIcons.pattern.metamodel',\n                'startDir':'transformation'},\n    callback = function(fnames)\n               {\n                    fnames.forEach( function(fname) {_loadToolbar(fname);} );\n               };\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
 				},
 				"$type": "/Formalisms/__Utilities__/Buttons/Buttons/Button"
 			},
@@ -950,7 +952,7 @@
 				},
 				"code": {
 					"type": "code",
-					"value": "var options  = {'extensions':['T_.*\\\\.model'],\n                'multipleChoice':false,\n                'title':'choose transformation model to load',\n                'startDir':'transformation'},\n    callback =  function(fnames)\n                {\n                    _loadModel(fnames[0]);\n                };\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
+					"value": "var options  = {'extensions':['T_.*\\\\.model'],\n                'multipleChoice':false,\n                'title':'choose transformation model to load\\nexample: T_translateToSC.model',\n                'startDir':'transformation'},\n    callback =  function(fnames)\n                {\n                    _loadModel(fnames[0]);\n                };\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
 				},
 				"$type": "/Formalisms/__Utilities__/Buttons/Buttons/Button"
 			},
@@ -965,7 +967,7 @@
 				},
 				"code": {
 					"type": "code",
-					"value": "var options = {'extensions':['\\\\.model'],\n\t       'multipleChoice':false,\n\t       'manualInput':true,\n               'title':'specify target model',\n               'startDir':'model'},\n    callback =\n\tfunction(fnames)\n\t{\n\t\t_newTransformation(fnames[0]);\n\t};\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
+					"value": "var options = {'extensions':['\\\\.model'],\n\t       'multipleChoice':false,\n\t       'manualInput':true,\n               'title':'specify target model\\nexample: T_translateToSC.model',\n               'startDir':'model'},\n    callback =\n\tfunction(fnames)\n\t{\n\t\t_newTransformation(fnames[0]);\n\t};\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
 				},
 				"$type": "/Formalisms/__Utilities__/Buttons/Buttons/Button"
 			},
@@ -980,14 +982,16 @@
 				},
 				"code": {
 					"type": "code",
-					"value": "var options = {'extensions':['\\\\.model'],\n\t       'multipleChoice':false,\n\t       'manualInput':true,\n               'title':'specify target model',\n               'startDir':'model'},\n    callback =\n\tfunction(fnames)\n\t{\n\t\t_newRule(fnames[0]);\n\t};\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
+					"value": "var options = {'extensions':['\\\\.model'],\n\t       'multipleChoice':false,\n\t       'manualInput':true,\n               'title':'specify target model\\nexample: R_TimedTransition.model',\n               'startDir':'model'},\n    callback =\n\tfunction(fnames)\n\t{\n\t\t_newRule(fnames[0]);\n\t};\nWindowManagement.openDialog(_FILE_BROWSER,options,callback);"
 				},
 				"$type": "/Formalisms/__Utilities__/Buttons/Buttons/Button"
 			}
 		},
 		"edges": [],
 		"metamodels": [
-			"/Formalisms/__Utilities__/Buttons/Buttons"
+			"/Formalisms/__Utilities__/Buttons/Buttons",
+			"/Formalisms/__LanguageSyntax__/ConcreteSyntax/ConcreteSyntax",
+			"/Formalisms/__LanguageSyntax__/SimpleClassDiagram/SimpleClassDiagram"
 		]
 	}
 }


### PR DESCRIPTION
As a quality-of-life change, add the file extensions that AToMPM expects the user to be loading or saving to.

For example, the icon definition model must be named *Icons.metamodel. This is difficult to know without finding examples in the manual.

![atompm](https://user-images.githubusercontent.com/4430283/39089783-98db3bf2-459c-11e8-8778-16d2670e95fe.png)
![atompm2](https://user-images.githubusercontent.com/4430283/39089784-99062858-459c-11e8-9021-5879331041a3.png)
![atompm3](https://user-images.githubusercontent.com/4430283/39089785-991f9e00-459c-11e8-8483-b2447eaaa96b.png)

