### PR TITLE
Add config for Travis CI, add test script, and fix up package file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+ - "node"
+    
+before_script:
+    pip install --user python-igraph
+    
+script:
+ - ./run_tests.sh
+    

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
-{ "name": "AToMPM",
+{
+  "name": "AToMPM",
   "version": "0.6.0",
   "description": "A Tool for Multi-Paradigm Modelling",
-  "bugs": 
-    {"url": "https://msdl.uantwerpen.be/git/simon/AToMPM/issues",
-     "email" : "simon.vanmierlo@uantwerpen.be"},
-  "repository" :
-      { "type" : "git",
-        "url" : "https://msdl.uantwerpen.be/git/simon/AToMPM"
-      },
-  "dependencies" :
-    {"socket.io" : "0.9.16",
-     "socket.io-client" : "0.9.16"}
+  "bugs": {
+    "url": "https://github.com/AToMPM/atompm/issues",
+    "email": "simon.vanmierlo@uantwerpen.be"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AToMPM/atompm"
+  },
+  "dependencies": {
+    "socket.io": "^0.9.19",
+    "socket.io-client": "^0.9.16"
+  }
 }

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#exit on errors
+set -e
+
+#run server
+node httpwsd.js &
+serverpid=$!
+sleep 3
+
+#check if server is dead
+if ! kill -0 "$serverpid"; then
+    wait $serverpid
+    server_status=$?
+    exit $server_status
+fi
+
+#run mt script
+python2 mt/main.py &
+mtpid=$!
+sleep 3
+
+#check if model transformer is dead
+if ! kill -0 "$mtpid"; then
+    wait $mtpid
+    mt_status=$?
+    exit $mt_status
+fi
+


### PR DESCRIPTION
This change adds Travis-CI support, such that builds are automatically run through continuous integration. Currently, the script run_tests.sh is run, which starts up the node server and mt/main.py script, and reports any errors. As well, this change modifies the package file to point to the new repo, and to update the package version for socket.io so that the build passes. 