### PR TITLE
Add testing in the Chrome browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ cache:
   directories:
     - "node_modules"
 
+sudo: required
+addons:
+  chrome: stable
+
 before_script:
-    pip install --user python-igraph
+ - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+ - pip install --user python-igraph
     
 script:
  - ./run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: node_js
 node_js:
  - "node"
-    
+
+cache:
+  directories:
+    - "node_modules"
+
 before_script:
     pip install --user python-igraph
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ addons:
   chrome: stable
 
 before_script:
- - xvfb-run make test
+ - "export DISPLAY=:99.0"
+ - "sh -e /etc/init.d/xvfb start"
+ - sleep 3 # give xvfb some time to start
 
  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
  - pip install --user python-igraph

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ addons:
   chrome: stable
 
 before_script:
+ - xvfb-run make test
+
  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
  - pip install --user python-igraph
     

--- a/client/atompm.html
+++ b/client/atompm.html
@@ -20,6 +20,7 @@ with AToMPM.  If not, see <http://www.gnu.org/licenses/>.
 
 <html>
 	<head>
+        <title>AToMPM</title>
 		<meta charset="utf-8">
 		<link rel="stylesheet" type="text/css" href="client/styles.css"/>
 		<script text="text/javascript" src="client/globalVariables.js"></script>

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -1,0 +1,62 @@
+const seleniumServer = require("selenium-server");
+const chromedriver = require("chromedriver");
+
+
+
+module.exports = {
+  "src_folders" : ["tests"],
+  "output_folder" : "reports",
+  "custom_commands_path" : "",
+  "custom_assertions_path" : "",
+  "page_objects_path" : "",
+  "globals_path" : "",
+
+  "selenium" : {
+    "start_process" : true,
+    "server_path" : seleniumServer.path,
+    "log_path" : "",
+    "port" : 4444,
+    "cli_args" : {
+      "webdriver.chrome.driver" : chromedriver.path,
+      "webdriver.gecko.driver" : "",
+      "webdriver.edge.driver" : ""
+    }
+  },
+
+  "test_settings" : {
+    "default" : {
+      "launch_url" : "http://localhost",
+      "selenium_port"  : 4444,
+      "selenium_host"  : "localhost",
+      "silent": true,
+      "screenshots" : {
+        "enabled" : false,
+        "path" : ""
+      },
+      "globals": {
+        "waitForConditionTimeout": 5000 // sometimes internet is slow so wait.
+      },
+      "desiredCapabilities": {
+        "browserName": "chrome",
+        "javascriptEnabled": true,
+        "marionette": true
+      }
+    },
+
+    "chrome" : {
+      "desiredCapabilities": {
+        "browserName": "chrome"
+      }
+    },
+
+    "edge" : {
+      "desiredCapabilities": {
+        "browserName": "MicrosoftEdge"
+      }
+    }
+  }
+};
+
+
+
+

--- a/package.json
+++ b/package.json
@@ -13,5 +13,13 @@
   "dependencies": {
     "socket.io": "^0.9.19",
     "socket.io-client": "^0.9.16"
+  },
+  "devDependencies": {
+    "nightwatch": "^0.9.21",
+    "selenium-server": "^3.12.0",
+    "chromedriver": "^2.38.3"
+  },
+  "scripts" : {
+    "test" : "./run_tests.sh"
   }
 }

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,6 +4,7 @@
 set -e
 
 #run server
+echo "Starting server..."
 node httpwsd.js &
 serverpid=$!
 sleep 3
@@ -16,6 +17,7 @@ if ! kill -0 "$serverpid"; then
 fi
 
 #run mt script
+echo "Starting model transformation script..."
 python2 mt/main.py &
 mtpid=$!
 sleep 3
@@ -27,3 +29,16 @@ if ! kill -0 "$mtpid"; then
     exit $mt_status
 fi
 
+echo "Starting tests..."
+
+#start nightwatch tests
+nightwatch
+
+
+echo "Stopping server and mt script..."
+kill "$serverpid"
+kill "$mtpid"
+
+
+
+echo "Finished!"

--- a/tests/startup_test.js
+++ b/tests/startup_test.js
@@ -1,0 +1,20 @@
+module.exports = {
+
+  beforeEach : function (browser) {
+    browser.url('http://localhost:8124/atompm').pause(300);
+  },
+
+  'Test Startup' : function (client) {
+
+    client.getTitle(function(title) {
+      this.assert.ok(title.includes("AToMPM"), "Title is AToMPM");
+    });
+
+
+  },
+
+  after : function (browser) {
+    browser.end();
+  },
+
+};


### PR DESCRIPTION
The Nightwatch testing framework is used to start a Selenium server, which loads up the AToMPM page. Elements can be examined and Javascript functions run inside the page, allowing for detailed and extensive testing.