### PR TITLE
Fix up model transformation issues

### DIFF
--- a/asworker.js
+++ b/asworker.js
@@ -139,14 +139,20 @@ module.exports = {
 			}
 
 
-
-			_do.chain(actions)(
-					function() 
-					{
-						__postMessage({'statusCode':200, 'respIndex':resp});
-					},
-					function(err) 	{__postInternalErrorMsg(resp,err);}
-			);
+            _do.chain(actions)(
+                function () {
+                    __postMessage({'statusCode': 200, 'respIndex': resp});
+                },
+                function (err) {
+                    if (err.includes("ECONNREFUSED")) {
+                        let msg = "could not connect to model transformation worker!\n" +
+                            "please ensure the worker is running!";
+                        __postInternalErrorMsg(resp, msg);
+                    } else {
+                        __postInternalErrorMsg(resp, err);
+                    }
+                }
+            );
 		},
 
 		

--- a/mt/mtworker.py
+++ b/mt/mtworker.py
@@ -187,7 +187,7 @@ class mtworkerThread(threading.Thread) :
 				self._postMessage(
 						msg['resp'],
 						{'statusCode':500,
-  						 'reason':str(e)})
+  						 'reason':"Error in model transformation worker: " + str(e)})
 				
 		elif msg['method'] == 'PUT' and re.match('/query.transform',msg['uri']):
 			try :

--- a/mt/ptcal/compiler.py
+++ b/mt/ptcal/compiler.py
@@ -521,7 +521,12 @@ class ModelAndRuleCompiler :
             fulltype = mm+'/'+type
             self._mmTypeData[fulltype] = {}
             for attr in mmData['types'][type] :
-                self._mmTypeData[fulltype][attr['name']] = attr['default']                
+
+                # if there is no default, provide an empty string
+                try:
+                    self._mmTypeData[fulltype][attr['name']] = attr['default']
+                except KeyError:
+                    self._mmTypeData[fulltype][attr['name']] = ""
 
 
     '''


### PR DESCRIPTION
* Add better MT debugging messages so that the user know when there's an issue with the MT worker, or the worker hasn't been started
* If there's no default value for a type, provide "" instead of crashing