### PR TITLE
Add Access-Control-Allow-Origin to headers

### DIFF
--- a/__worker.js
+++ b/__worker.js
@@ -151,7 +151,8 @@ function __httpReq(method,url,data,port)
 				 if( data != undefined )
 				 {
 					 data = _utils.jsons(data);
-					 options['headers'] = {'Content-Length':unescape(encodeURIComponent(data)).length};
+					 options['headers'] = {'Content-Length':unescape(encodeURIComponent(data)).length,
+					 'Access-Control-Allow-Origin': '*'};
 				 }
 
 				 var request = 

--- a/httpwsd.js
+++ b/httpwsd.js
@@ -39,7 +39,8 @@ function __respond(response, statusCode, reason, data, headers)
 	response.writeHead(
 			statusCode,
 			JSON.stringify(reason),
-			(headers || {'Content-Type': 'text/plain'}));
+			(headers || {'Content-Type': 'text/plain',
+			'Access-Control-Allow-Origin': '*'}));
 
 	var encoding = 
 		(headers && 
@@ -60,11 +61,11 @@ function __respond(response, statusCode, reason, data, headers)
 /** Syntactic sugar to build and send a socket.io message **/
 function __send(socket, statusCode, reason, data, headers)
 {
-//headers['Access-Control-Allow-Origin'] = 'http://raven10.kicks-ass.net:8080';
 	socket.json.emit('message',
 			{'statusCode':statusCode,
 			 'reason':reason,
-			 'headers':(headers || {'Content-Type': 'text/plain'}),
+			 'headers':(headers || {'Content-Type': 'text/plain',
+			 'Access-Control-Allow-Origin': '*'}),
 			 'data':data});
 }
 
@@ -649,7 +650,8 @@ var httpserver = _http.createServer(
 								JSON.stringify(
 									{'headers':
 										(msg['headers'] || 
-										 {'Content-Type': 'text/plain'}),
+										 {'Content-Type': 'text/plain',
+										 'Access-Control-Allow-Origin': '*'}),
 									 'data':msg['data'],
 									 'sequence#':msg['sequence#']}),
 								{'Content-Type': 'application/json'});

--- a/mt/ptcal/utils.py
+++ b/mt/ptcal/utils.py
@@ -67,7 +67,7 @@ class Utilities :
 		send a synchronous http request '''
 	@staticmethod
 	def httpReq(method,host,uri,data) :
-		headers = {'Content-Type': 'text/plain'}
+		headers = {'Content-Type': 'text/plain', 'Access-Control-Allow-Origin': '*'}
 		conn = httplib.HTTPConnection(host)
 		conn.request(method, uri, json.dumps(data), headers)
 		resp = conn.getresponse()


### PR DESCRIPTION
Adding the header 'Access-Control-Allow-Origin': '*' everywhere should fix errors with cross-domain requests. These requests are seen with the ModelVerse work, and with the upgrade of socket.io