### PR TITLE
Concrete syntax meta-model icon to have file picker by default instea…

### DIFF
--- a/users/(default)/Formalisms/__LanguageSyntax__/ConcreteSyntax/ConcreteSyntaxMM.model
+++ b/users/(default)/Formalisms/__LanguageSyntax__/ConcreteSyntax/ConcreteSyntaxMM.model
@@ -5687,7 +5687,7 @@
 					"value": [
 						{
 							"name": "src",
-							"type": "string",
+							"type": "file<png|jpg|gif|bmp>",
 							"default": "/Formalisms/__LanguageSyntax__/ConcreteSyntax/defaultImage.png"
 						},
 						{


### PR DESCRIPTION
…d of typing full path
https://user-images.githubusercontent.com/3879710/97815714-b871bb00-1c98-11eb-8454-caa0e2c6b58c.gif
