### PR TITLE
Maintainability and formatting fixes to worker files

### DIFF
--- a/asworker.js
+++ b/asworker.js
@@ -36,18 +36,17 @@ module.exports = {
 	'mtwRequest' :
 		function(resp,method,uri,reqData)
 		{
-			var self	   = this,
-				 actions = 
-				 	[__successContinuable(),
-	 				 function()
-	 				 {
-						 uri = uri.substring('/__mt'.length);
-	 					 return __httpReq(
-								 		method,
-										uri+'?wid='+self.__mtwid,
-										reqData,
-										8125);
-	 				 }];
+			let self = this;
+			let actions =
+				[__successContinuable(),
+					function () {
+						uri = uri.substring('/__mt'.length);
+						return __httpReq(
+							method,
+							uri + '?wid=' + self.__mtwid,
+							reqData,
+							8125);
+					}];
 
 			if( this.__mtwid == undefined )
 			{
@@ -55,8 +54,7 @@ module.exports = {
 					 reqData['transfs'] == undefined ||
 					 reqData['transfs'].length == 0 )
 					return __postInternalErrorMsg(resp,'missing transformations');
-				else if( reqData == undefined || 
-  							reqData['username'] == undefined ||
+				else if( reqData['username'] == undefined ||
 	  						reqData['username'].length == 0 )
 					return __postInternalErrorMsg(resp,'missing username');
 
@@ -106,18 +104,22 @@ module.exports = {
 	  					},
   						function()
   						{
-							if( (mms = _mmmk.readMetamodels())['$err'] )
+							let mms = _mmmk.readMetamodels();
+							if (mms['$err'])
 								return __errorContinuable(mms['$err']);
-	  						else if( (m = _mmmk.read())['$err'] )
+							let m = _mmmk.read();
+							if (m['$err'])
 								return __errorContinuable(m['$err']);
-								
-  							return __httpReq(
-										'PUT',
-  										'/current.model?wid='+self.__mtwid,
-										{'mms':mms,
-										 'm':m, 
-										 'sequence#':__sequenceNumber(0)},
-  										8125);
+
+							return __httpReq(
+								'PUT',
+								'/current.model?wid=' + self.__mtwid,
+								{
+									'mms': mms,
+									'm': m,
+									'sequence#': __sequenceNumber(0)
+								},
+								8125);
   						},
   						function()
   						{
@@ -167,22 +169,25 @@ module.exports = {
 	'PUT /current.metamodels' :
 		function(resp,uri,reqData/*mm,hitchhiker*/)
 		{
-			var actions = [__successContinuable()]; 
+			let actions = [__successContinuable()];
 
 			if( reqData['hitchhiker'] == undefined ||
 				 'path' in reqData['hitchhiker'] )
 				actions.push(
 					function()
 					{
-						var ext  = (reqData['mm'].match(/\.pattern\.metamodel$/) ?
-											'.pattern.metamodel' :
-											'.metamodel'),
-							 path = 
-							(reqData['hitchhiker'] && 'path' in reqData['hitchhiker'] ?
-								reqData['hitchhiker']['path'] :
-								reqData['mm'].match(/(.*)\.metamodel/)[1]+
-										'.defaultIcons'+ext),
-							 name = path.match(/.+?(\/.*)\.metamodel/)[1];
+						let ext;
+						if (reqData['mm'].match(/\.pattern\.metamodel$/))
+							ext = '.pattern.metamodel';
+						else
+							ext = '.metamodel';
+
+						let path;
+						if (reqData['hitchhiker'] && 'path' in reqData['hitchhiker'])
+							path = reqData['hitchhiker']['path'];
+						else
+							path = reqData['mm'].match(/(.*)\.metamodel/)[1] + '.defaultIcons' + ext;
+						let name = path.match(/.+?(\/.*)\.metamodel/)[1];
 
 						reqData['hitchhiker'] = {};											
 						reqData['hitchhiker']['name'] = name;
@@ -203,8 +208,8 @@ module.exports = {
 			_do.chain(actions)(
 					function(asmmData) 
 					{
-  						var mm  = reqData['mm'].match(/.+?(\/.*)\.metamodel/)[1],
-							 res = _mmmk.loadMetamodel(mm,asmmData);
+						let mm = reqData['mm'].match(/.+?(\/.*)\.metamodel/)[1];
+						let res = _mmmk.loadMetamodel(mm, asmmData);
 						__postMessage(
 							{'statusCode':200, 
 	  						 'changelog':res['changelog'],
@@ -227,8 +232,8 @@ module.exports = {
 	'DELETE *.metamodel' :
 		function(resp,uri)
 		{
-			var mm  = uri.match(/(.*)\.metamodel/)[1],
-				 res = _mmmk.unloadMetamodel(mm);
+			let mm  = uri.match(/(.*)\.metamodel/)[1];
+			let res = _mmmk.unloadMetamodel(mm);
 			__postMessage(
 					{'statusCode':200, 
 					 'changelog':res['changelog'],
@@ -239,20 +244,19 @@ module.exports = {
 
 	/* load a model */
 	'PUT /current.model' :
-		function(resp,uri,reqData/*m,name,insert,hitchhiker*/)
-		{
-			if( (res = _mmmk.loadModel(
-										reqData['name'],
-										reqData['m'],
-										reqData['insert']))['$err'] )
-				__postInternalErrorMsg(resp,res['$err']);
+		function (resp, uri, reqData/*m,name,insert,hitchhiker*/) {
+			let res = _mmmk.loadModel(reqData['name'], reqData['m'], reqData['insert']);
+			if (res['$err'])
+				__postInternalErrorMsg(resp, res['$err']);
 			else
 				__postMessage(
-						{'statusCode':200, 
-  						 'changelog':res['changelog'],	
-					 	 'sequence#':__sequenceNumber(),
-						 'hitchhiker':reqData['hitchhiker'],
-						 'respIndex':resp});
+					{
+						'statusCode': 200,
+						'changelog': res['changelog'],
+						'sequence#': __sequenceNumber(),
+						'hitchhiker': reqData['hitchhiker'],
+						'respIndex': resp
+					});
 		},
 
 
@@ -272,15 +276,18 @@ module.exports = {
 	'POST *.type' :
 		function(resp,uri,reqData/*[src,dest],hitchhiker,attrs*/)
 		{
-			var matches 	= uri.match(/(.*)\.type/),
-				 fulltype 	= matches[1],
-				 res  		= (reqData == undefined || reqData['src'] == undefined ?
-									 _mmmk.create(fulltype,reqData['attrs']) :
-									 _mmmk.connect(
-										 __uri_to_id(reqData['src']),
-										 __uri_to_id(reqData['dest']),
-										 fulltype,
-										 reqData['attrs']));
+			let matches 	= uri.match(/(.*)\.type/);
+			let fulltype 	= matches[1];
+			let res;
+			if (reqData == undefined || reqData['src'] == undefined) {
+				res = _mmmk.create(fulltype, reqData['attrs']);
+			} else {
+				res = _mmmk.connect(
+					__uri_to_id(reqData['src']),
+					__uri_to_id(reqData['dest']),
+					fulltype,
+					reqData['attrs']);
+			}
 
 			if( '$err' in res )
 				__postInternalErrorMsg(resp,res['$err']);
@@ -299,9 +306,9 @@ module.exports = {
 	'GET *.instance' :
 		function(resp,uri)
 		{
-			var id = __uri_to_id(uri);
-
-			if( (res = _mmmk.read(id))['$err'] )
+			let id = __uri_to_id(uri);
+			let res = _mmmk.read(id)
+			if( res['$err'] )
 				__postInternalErrorMsg(resp,res['$err']);
 			else
 				__postMessage(
@@ -318,24 +325,24 @@ module.exports = {
 				 bundled, we return a dummy changelog that ensures the said to-do-
 				 cschanges get handled by csworker.__applyASWChanges().CHATTR */
 	'PUT *.instance' :
-		function(resp,uri,reqData/*changes[,hitchhiker]*/)
-		{
-			var id = __uri_to_id(uri);
-
-			if( (res = _mmmk.update(id,reqData['changes']))['$err'] )
-				__postInternalErrorMsg(resp,res['$err']);
-			else
-			{
-				var changelog = 
-						(res['changelog'].length == 0 && reqData['hitchhiker'] ?
-						 	[{'op':'CHATTR','id':id}] :
-							res['changelog']);
+		function (resp, uri, reqData/*changes[,hitchhiker]*/) {
+			let id = __uri_to_id(uri);
+			let res = _mmmk.update(id, reqData['changes']);
+			if (res['$err'])
+				__postInternalErrorMsg(resp, res['$err']);
+			else {
+				let changelog = res['changelog'];
+				if (res['changelog'].length == 0 && reqData['hitchhiker']) {
+					changelog = [{'op': 'CHATTR', 'id': id}];
+				}
 				__postMessage(
-					{'statusCode':200, 
-					 'changelog':changelog,
-					 'sequence#':__sequenceNumber(),
-					 'hitchhiker':reqData['hitchhiker'],
-					 'respIndex':resp});
+					{
+						'statusCode': 200,
+						'changelog': changelog,
+						'sequence#': __sequenceNumber(),
+						'hitchhiker': reqData['hitchhiker'],
+						'respIndex': resp
+					});
 			}
 		},
 
@@ -352,19 +359,26 @@ module.exports = {
 				 NOTE for csworker.DELETE *.instance with the difference that in 
 				 this context, the client is the mtworker) */
 	'DELETE *.instance' :
-		function(resp,uri)
-		{
-			var id = __uri_to_id(uri);
-			if( (res = _mmmk.read(id))['$err'] )
-				__postMessage({'statusCode':200, 'respIndex':resp});
-			else if( (res = _mmmk['delete'](id))['$err'] )
-				__postInternalErrorMsg(resp,res['$err']);
-			else
-				__postMessage(
-					{'statusCode':200, 
-					 'changelog':res['changelog'],
-					 'sequence#':__sequenceNumber(),
-					 'respIndex':resp});
+		function (resp, uri) {
+			let id = __uri_to_id(uri);
+			let res = _mmmk.read(id)
+			if (res['$err']) {
+				__postMessage({'statusCode': 200, 'respIndex': resp});
+				return;
+			}
+			res = _mmmk['delete'](id);
+			if (res['$err']) {
+				__postInternalErrorMsg(resp, res['$err']);
+				return;
+			}
+
+			__postMessage(
+				{
+					'statusCode': 200,
+					'changelog': res['changelog'],
+					'sequence#': __sequenceNumber(),
+					'respIndex': resp
+				});
 		},
 
 
@@ -377,27 +391,33 @@ module.exports = {
 	'PUT *.metamodel' :
 		function(resp,uri,reqData/*[csm]*/)
 		{
-			if( uri.match(/(.*)\..*Icons\.metamodel/) && 
-				 (res = _mmmk.
-						compileToIconDefinitionMetamodel(reqData['csm'], reqData['asmm']))['$err'] )
-				__postInternalErrorMsg(resp,res['$err']);
-			else if( ! uri.match(/(.*)\..*Icons\.metamodel/) &&
-						(res = _mmmk.compileToMetamodel())['$err'] )
-				__postInternalErrorMsg(resp,res['$err']);
-			else
-			{
-				var uri 		= uri.substring('/GET'.length),
-					 actions = [_fs.writeFile('./users'+uri,res)];
-				_do.chain(actions)(
-						function() 
-						{
-							__postMessage(
-								{'statusCode':200, 
-								 'respIndex':resp});
-						},
-						function(err) 	{__postInternalErrorMsg(resp,err);}
-				);
+			let res;
+			if (uri.match(/(.*)\..*Icons\.metamodel/)) {
+				res = _mmmk.compileToIconDefinitionMetamodel(reqData['csm'], reqData['asmm'])
+			} else {
+				res = _mmmk.compileToMetamodel();
 			}
+
+			if (res['$err']) {
+				__postInternalErrorMsg(resp, res['$err']);
+				return;
+			}
+
+			let uri2 = uri.substring('/GET'.length);
+			let actions = [_fs.writeFile('./users' + uri2, res)];
+			_do.chain(actions)(
+				function () {
+					__postMessage(
+						{
+							'statusCode': 200,
+							'respIndex': resp
+						});
+				},
+				function (err) {
+					__postInternalErrorMsg(resp, err);
+				}
+			);
+
 		},
 
 
@@ -405,7 +425,7 @@ module.exports = {
 	'GET /validatem' :
 		function(resp)
 		{
-			var err = _mmmk.validateModel();
+			let err = _mmmk.validateModel();
 			if( err )
 				__postInternalErrorMsg(resp,err['$err']);
 			else
@@ -456,40 +476,38 @@ module.exports = {
 			however, due to the possibly large amount of reqData it requires, we're
 			forced to make it a POST */
 	'POST *.mappings' :
-		function(resp,uri,reqData/*{...,fullvid:mapper,...}*/)
-		{
-			var id  		 = __uri_to_id(uri),
-				 attrVals = {};
+		function (resp, uri, reqData/*{...,fullvid:mapper,...}*/) {
+			let id = __uri_to_id(uri);
+			let attrVals = {};
 
-			for( var fullvid in reqData )
-			{
-				var res = _mmmk.runDesignerAccessorCode(
-									 reqData[fullvid],
-									 'mapper evaluation ('+uri+')',
- 									 id);
-				if( res == undefined )
-					continue; 
-				else if( !_utils.isObject(res) )
-				{
-					attrVals = 
-						{'$err':
-						 'mapper returned non-dictionary type :: '+(typeof res)};
+			for (let fullvid in reqData) {
+				let res = _mmmk.runDesignerAccessorCode(
+					reqData[fullvid],
+					'mapper evaluation (' + uri + ')',
+					id);
+				if (res == undefined)
+					continue;
+				else if (!_utils.isObject(res)) {
+					attrVals =
+						{
+							'$err':
+								'mapper returned non-dictionary type :: ' + (typeof res)
+						};
 					break;
-				}
-				else if( '$err' in res )
-				{
+				} else if ('$err' in res) {
 					attrVals = res;
 					break;
-				}
-				else
-					for( var attr in res )
-						attrVals[fullvid+attr] = res[attr];
+				} else
+					for (let attr in res)
+						attrVals[fullvid + attr] = res[attr];
 			}
 
 			__postMessage(
-					{'statusCode':200,
-					 'data':attrVals,
-					 'respIndex':resp});
+				{
+					'statusCode': 200,
+					'data': attrVals,
+					'respIndex': resp
+				});
 		},
 
 

--- a/csworker.js
+++ b/csworker.js
@@ -179,22 +179,22 @@
 			__handledSeqNums */
 
 const {
-	__batchCheckpoint,
+    __batchCheckpoint,
     __errorContinuable,
-	GET__current_state,
-	get__ids2uris,
-	set__ids2uris,
-	get__nextSequenceNumber,
-	set__nextSequenceNumber,
-	get__wtype,
-     __httpReq,
-	__id_to_uri,
-	__wHttpReq,
+    GET__current_state,
+    get__ids2uris,
+    set__ids2uris,
+    get__nextSequenceNumber,
+    set__nextSequenceNumber,
+    get__wtype,
+    __httpReq,
+    __id_to_uri,
+    __wHttpReq,
     __postInternalErrorMsg, __postMessage,
-	__postBadReqErrorMsg, __postForbiddenErrorMsg,
+    __postBadReqErrorMsg, __postForbiddenErrorMsg,
     __sequenceNumber,
     __successContinuable,
-	__uri_to_id
+    __uri_to_id
 } = require("./__worker");
 
 const _path = require('path');
@@ -202,7 +202,7 @@ const _siocl = require('socket.io-client');
 
 const _do = require("./___do");
 const _fs = _do.convert(require('fs'), ['readFile', 'writeFile', 'readdir']);
-const _fspp	= _do.convert(require('./___fs++'), ['mkdirs']);
+const _fspp = _do.convert(require('./___fs++'), ['mkdirs']);
 
 const _mmmk = require("./mmmk");
 const _mt = require('./libmt');
@@ -212,116 +212,113 @@ const _utils = require('./utils');
 const logger = require('./logger.js')
 logger.set_level(logger.LOG_LEVELS.INFO);
 
- module.exports = {
-	'__REGEN_ICON_RETRY_DELAY_MS':200,
-	'__asmm2csmm':{},
-	'__asid2csid':{},
-	'__aswid':undefined,
-	'__handledSeqNums':{'i':undefined,'#s':[]},
-
-	
-	/*************************** ASWORKER INTERACTION **************************/
-	/* apply asworker changes 
-
-		0. check the changelog's sequence number to know if we should handle it 
-			now or later
-		1. iterate through the AS changelog setting up sync/async actions that 
-			appropriately modify the CS while accumulating CS changelogs (for 
-			pushing to subscribed clients)
-		2. launch sync/async action chain... on error, post error... on success,
-			a) flatten the CS changelogs into a single changelog
-			b) post message to server with flattened CS changelog, the server will
-				then push it to subscribed clients 
-			c) apply next pending asworker changelog, if any and if applicable
-	
-		__nextASWSequenceNumber 
-				used to determine if a changelog is received out of order, and if a
-			  	pending changelog is now ready to be handled
-		__pendingChangelogs 
-				stores out or order changelogs until we're ready to handle them 
-		 __hitchhikerJournal
-		 		stores encountered hithchikers for future use (see NOTES above) */
-	'__nextASWSequenceNumber':'/asworker#1',
-	'__pendingChangelogs':[],
-	'__hitchhikerJournal':{},
-	'__applyASWChanges' :
-		function(changelog,aswSequenceNumber,hitchhiker)
-		{
-			let log_chs = _utils.collapse_changelog(changelog);
-			logger.debug('worker#'+__wid+' << ('+aswSequenceNumber+') ' + _utils.jsons(log_chs));
+module.exports = {
+    '__REGEN_ICON_RETRY_DELAY_MS': 200,
+    '__asmm2csmm': {},
+    '__asid2csid': {},
+    '__aswid': undefined,
+    '__handledSeqNums': {'i': undefined, '#s': []},
 
 
-			if( _utils.sn2int(aswSequenceNumber) > 
-				 	_utils.sn2int(this.__nextASWSequenceNumber) )
-			{
-				this.__pendingChangelogs.push(
-							{'changelog':changelog,
-							 'sequence#':aswSequenceNumber,
-	 						 'hitchhiker':hitchhiker});
-				var self = this;
-				this.__pendingChangelogs.sort(
-					function(a,b)
-					{
-						return self.__sn2int(a['sequence#']) - 
-									self.__sn2int(b['sequence#']);
-					});
-				return;
-			}
-			else if( _utils.sn2int(aswSequenceNumber) < 
-							_utils.sn2int(this.__nextASWSequenceNumber) )
-				throw 'invalid changelog sequence#';
+    /*************************** ASWORKER INTERACTION **************************/
+    /* apply asworker changes
+
+        0. check the changelog's sequence number to know if we should handle it
+            now or later
+        1. iterate through the AS changelog setting up sync/async actions that
+            appropriately modify the CS while accumulating CS changelogs (for
+            pushing to subscribed clients)
+        2. launch sync/async action chain... on error, post error... on success,
+            a) flatten the CS changelogs into a single changelog
+            b) post message to server with flattened CS changelog, the server will
+                then push it to subscribed clients
+            c) apply next pending asworker changelog, if any and if applicable
+
+        __nextASWSequenceNumber
+                used to determine if a changelog is received out of order, and if a
+                  pending changelog is now ready to be handled
+        __pendingChangelogs
+                stores out or order changelogs until we're ready to handle them
+         __hitchhikerJournal
+                 stores encountered hithchikers for future use (see NOTES above) */
+    '__nextASWSequenceNumber': '/asworker#1',
+    '__pendingChangelogs': [],
+    '__hitchhikerJournal': {},
+    '__applyASWChanges':
+        function (changelog, aswSequenceNumber, hitchhiker) {
+            let log_chs = _utils.collapse_changelog(changelog);
+            logger.debug('worker#' + __wid + ' << (' + aswSequenceNumber + ') ' + _utils.jsons(log_chs));
 
 
-			var cschangelogs 		= [],
-				 cshitchhiker,
-				 actions 	  		= [__successContinuable()],
-				 self			  		= this;
+            if (_utils.sn2int(aswSequenceNumber) >
+                _utils.sn2int(this.__nextASWSequenceNumber)) {
+                this.__pendingChangelogs.push(
+                    {
+                        'changelog': changelog,
+                        'sequence#': aswSequenceNumber,
+                        'hitchhiker': hitchhiker
+                    });
+                let self = this;
+                this.__pendingChangelogs.sort(
+                    function (a, b) {
+                        return self.__sn2int(a['sequence#']) -
+                            self.__sn2int(b['sequence#']);
+                    });
+                return;
+            } else if (_utils.sn2int(aswSequenceNumber) <
+                _utils.sn2int(this.__nextASWSequenceNumber))
+                throw 'invalid changelog sequence#';
 
-			/* special handling of undo/redo changelogs (see NOTES above) */
-			if( hitchhiker && 'undo' in hitchhiker )
-				cschangelogs.push(_mmmk.undo(hitchhiker['undo'])['changelog']);
-			else if( hitchhiker && 'redo' in hitchhiker )
-				cschangelogs.push(_mmmk.redo(hitchhiker['redo'])['changelog']);
 
-			/* special handling of batchCheckpoint changelogs (see NOTES above) */
-			else if( changelog.length == 1 && changelog[0]['op'] == 'MKBTCCHKPT' )
-				this.__checkpointUserOperation(changelog[0]['name']);
+            let cschangelogs = [];
+            let cshitchhiker;
+            let actions = [__successContinuable()];
+            let self = this;
 
-			/* handle any other changelog */
-			else
-			{
-				var manageHitchhiker = 
-						function(hhid,hh)
-						{
-							/* remember/restore a hitchhiker given specified id */
-							if( hh )
-								self.__hitchhikerJournal[hhid] = hh;
-							else if( hitchhiker )	
-								self.__hitchhikerJournal[hhid] = hitchhiker;
-							else
-								hitchhiker = self.__hitchhikerJournal[hhid];
-						};
+            /* special handling of undo/redo changelogs (see NOTES above) */
+            if (hitchhiker && 'undo' in hitchhiker) {
+                let chglg = _mmmk.undo(hitchhiker['undo'])['changelog']
+                cschangelogs.push(chglg);
+            } else if (hitchhiker && 'redo' in hitchhiker) {
+                let chglg = _mmmk.redo(hitchhiker['redo'])['changelog']
+                cschangelogs.push(chglg);
+            }
 
-				this.__checkpointUserOperation(aswSequenceNumber);
-				changelog.forEach(
-					function(step)
-					{
-						/* no legal connections exist between *Icon types, so we 
-							simply simulate the CS change such a [dis]connection would
-						  	incur */
-						if( step['op'] == 'MKEDGE' || step['op'] == 'RMEDGE' )
-							actions.push(
-								function()
-								{
-									var asid1 = step['id1'],
-	  									 asid2 = step['id2'],
-										 csid1 = self.__asid_to_csid(asid1),
-										 csid2 = self.__asid_to_csid(asid2);
+            /* special handling of batchCheckpoint changelogs (see NOTES above) */
+            else if (changelog.length == 1 && changelog[0]['op'] == 'MKBTCCHKPT')
+                this.__checkpointUserOperation(changelog[0]['name']);
 
-									cschangelogs.push(
-										[{'op':step['op'],'id1':csid1,'id2':csid2}]);
-									return __successContinuable();
-								});
+            /* handle any other changelog */
+            else {
+                let manageHitchhiker =
+                    function (hhid, hh) {
+                        /* remember/restore a hitchhiker given specified id */
+                        if (hh)
+                            self.__hitchhikerJournal[hhid] = hh;
+                        else if (hitchhiker)
+                            self.__hitchhikerJournal[hhid] = hitchhiker;
+                        else
+                            hitchhiker = self.__hitchhikerJournal[hhid];
+                    };
+
+                this.__checkpointUserOperation(aswSequenceNumber);
+                changelog.forEach(
+                    function (step) {
+                        /* no legal connections exist between *Icon types, so we
+                            simply simulate the CS change such a [dis]connection would
+                              incur */
+                        if (step['op'] == 'MKEDGE' || step['op'] == 'RMEDGE')
+                            actions.push(
+                                function () {
+                                    let asid1 = step['id1'];
+                                    let asid2 = step['id2'];
+                                    let csid1 = self.__asid_to_csid(asid1);
+                                    let csid2 = self.__asid_to_csid(asid2);
+
+                                    cschangelogs.push(
+                                        [{'op': step['op'], 'id1': csid1, 'id2': csid2}]);
+                                    return __successContinuable();
+                                });
 
                         /* create appropriate CS instance and associate it with new AS
                             instance (remember the association in __asid2csid to
@@ -331,15 +328,15 @@ logger.set_level(logger.LOG_LEVELS.INFO);
                                 function () {
                                     manageHitchhiker(step['id']);
 
-                                    let asid = step['id'],
-                                        node = _utils.jsonp(step['node']),
-                                        isLink = ('segments' in hitchhiker),
-                                        fullastype = node['$type'],
-                                        fullcstype = self.__astype_to_cstype(
-                                            fullastype,
-                                            isLink),
-                                        asuri = fullastype + '/' + asid + '.instance',
-                                        attrs = {'$asuri': asuri};
+                                    let asid = step['id'];
+                                    let node = _utils.jsonp(step['node']);
+                                    let isLink = ('segments' in hitchhiker);
+                                    let fullastype = node['$type'];
+                                    let fullcstype = self.__astype_to_cstype(
+                                        fullastype,
+                                        isLink);
+                                    let asuri = fullastype + '/' + asid + '.instance';
+                                    let attrs = {'$asuri': asuri};
 
                                     if ('pos' in hitchhiker)
                                         attrs['position'] = hitchhiker['pos'];
@@ -348,8 +345,7 @@ logger.set_level(logger.LOG_LEVELS.INFO);
                                             hitchhiker['neighborhood']);
                                         attrs['position'] =
                                             [(nc[0] || 200), (nc[1] || 200)];
-                                    }
-                                    else if ('clone' in hitchhiker)
+                                    } else if ('clone' in hitchhiker)
                                         attrs = _utils.mergeDicts(
                                             [attrs, hitchhiker['clone']]);
                                     else
@@ -375,11 +371,8 @@ logger.set_level(logger.LOG_LEVELS.INFO);
                                         s[src + '--' + __id_to_uri(csid)] = segments[0];
                                         s[__id_to_uri(csid) + '--' + dest] = segments[1];
 
-                                        cschangelogs.push(
-                                            _mmmk.update(
-                                                csid,
-                                                {'$segments': s})['changelog'],
-                                            self.__positionLinkDecorators(csid));
+                                        let chglg = _mmmk.update(csid, {'$segments': s})['changelog'];
+                                        cschangelogs.push(chglg, self.__positionLinkDecorators(csid));
                                     }
 
                                     return self.__regenIcon(csid);
@@ -389,92 +382,90 @@ logger.set_level(logger.LOG_LEVELS.INFO);
                                     return __successContinuable();
                                 });
                         }
-						/* remove appropriate CS instance... update __asid2csid for it
-						  	to remain consistent */				
-						else if( step['op'] == 'RMNODE' )
-							actions.push(
-								function()
-								{
-									var asid = step['id'],
-										 csid	= self.__asid_to_csid(asid);
+                        /* remove appropriate CS instance... update __asid2csid for it
+                              to remain consistent */
+                        else if (step['op'] == 'RMNODE')
+                            actions.push(
+                                function () {
+                                    let asid = step['id'];
+                                    let csid = self.__asid_to_csid(asid);
 
-									cschangelogs.push(_mmmk['delete'](csid)['changelog']);
-									delete self.__asid2csid[asid];
-									return __successContinuable();
-								});
-	
-						/* regenerate the icon to re-evaluate any coded attributes
+                                    let chglg = _mmmk.delete(csid)['changelog']
+                                    cschangelogs.push(chglg);
+                                    delete self.__asid2csid[asid];
+                                    return __successContinuable();
+                                });
 
-							NOTE:: CS changes may be bundled (i.e., if an AS update was
-									 simulated by a CS update)... if so, perform them
-									 before regenerating the icon */
-						else if( step['op'] == 'CHATTR' )
-							actions.push(
-								function()
-								{
-									var asid	= step['id'],
-										 csid	= self.__asid_to_csid(asid);
+                        /* regenerate the icon to re-evaluate any coded attributes
 
-									if( hitchhiker && 'cschanges' in hitchhiker )
-									{
-										var cschanges = hitchhiker['cschanges'];
+                            NOTE:: CS changes may be bundled (i.e., if an AS update was
+                                     simulated by a CS update)... if so, perform them
+                                     before regenerating the icon */
+                        else if (step['op'] == 'CHATTR')
+                            actions.push(
+                                function () {
+                                    let asid = step['id'];
+                                    let csid = self.__asid_to_csid(asid);
 
-										cschangelogs.push(
-											_mmmk.update(csid,cschanges)['changelog'],
-											('$segments' in cschanges ?
-									 			self.__positionLinkDecorators(csid) :
-												[]));
-									}
-									return self.__regenIcon(csid);
-								},
-								function(riChangelog)
-								{
-									cschangelogs.push(riChangelog);
-									return __successContinuable();
-								});
-	
-						/* load appropriate CS metamodel (stored in hitchhiker)... 
-							remember AS-to-CS metamodel mapping in __asmm2csmm to 
-							optimize future operations */			
-						else if( step['op'] == 'LOADMM' )
-							actions.push(
-								function()
-								{
-									manageHitchhiker(step['name']);
-	
-									var asmm = step['name'],
-		  								 csmm = hitchhiker['name'],
-										 data = hitchhiker['csmm'];
+                                    if (hitchhiker && 'cschanges' in hitchhiker) {
+                                        let cschanges = hitchhiker['cschanges'];
 
-									cschangelogs.push(
-										_mmmk.loadMetamodel(csmm,data)['changelog'],
-										{'op':'LOADASMM',
-										 'name':asmm,
-										 'mm':step['mm']});
-					 				self.__asmm2csmm[asmm] = csmm;
-									return __successContinuable();
-								});
+                                        let chglg = _mmmk.update(csid, cschanges)['changelog'];
+                                        cschangelogs.push(chglg,
+                                            ('$segments' in cschanges ?
+                                                self.__positionLinkDecorators(csid) :
+                                                []));
+                                    }
+                                    return self.__regenIcon(csid);
+                                },
+                                function (riChangelog) {
+                                    cschangelogs.push(riChangelog);
+                                    return __successContinuable();
+                                });
 
-						/* unload appropriate CS metamodel... update __asmm2csmm for
-						  	it to remain consistent */			
-						else if( step['op'] == 'DUMPMM' )
-							actions.push(
-								function()
-								{
-									var asmm 	 = step['name'],
-		  								 csmm 	 = self.__asmm2csmm[asmm];
+                        /* load appropriate CS metamodel (stored in hitchhiker)...
+                            remember AS-to-CS metamodel mapping in __asmm2csmm to
+                            optimize future operations */
+                        else if (step['op'] == 'LOADMM')
+                            actions.push(
+                                function () {
+                                    manageHitchhiker(step['name']);
 
-									cschangelogs.push(_mmmk.unloadMetamodel(csmm)['changelog']);
-					 				delete self.__asmm2csmm[asmm];							
-									return __successContinuable();
-								});
-	
-						/* load appropriate CS model (stored in hitchhiker) and 
-							overwrite past hitchhiker associated to initial load of
-						  	current model, if any... when step['insert'] is specified,
-							adjust $asuris to compensate for offsetting of inserted asm
-							and $segments to compensate for upcoming offsetting of to-
-							be-inserted csm */
+                                    let asmm = step['name'];
+                                    let csmm = hitchhiker['name'];
+                                    let data = hitchhiker['csmm'];
+
+                                    let chglg = _mmmk.loadMetamodel(csmm, data)['changelog'];
+                                    cschangelogs.push(chglg,
+                                        {
+                                            'op': 'LOADASMM',
+                                            'name': asmm,
+                                            'mm': step['mm']
+                                        });
+                                    self.__asmm2csmm[asmm] = csmm;
+                                    return __successContinuable();
+                                });
+
+                        /* unload appropriate CS metamodel... update __asmm2csmm for
+                              it to remain consistent */
+                        else if (step['op'] == 'DUMPMM')
+                            actions.push(
+                                function () {
+                                    let asmm = step['name'];
+                                    let csmm = self.__asmm2csmm[asmm];
+
+                                    let chglg = _mmmk.unloadMetamodel(csmm)['changelog']
+                                    cschangelogs.push(chglg);
+                                    delete self.__asmm2csmm[asmm];
+                                    return __successContinuable();
+                                });
+
+                        /* load appropriate CS model (stored in hitchhiker) and
+                            overwrite past hitchhiker associated to initial load of
+                              current model, if any... when step['insert'] is specified,
+                            adjust $asuris to compensate for offsetting of inserted asm
+                            and $segments to compensate for upcoming offsetting of to-
+                            be-inserted csm */
                         else if (step['op'] == 'RESETM')
                             actions.push(
                                 function () {
@@ -483,20 +474,20 @@ logger.set_level(logger.LOG_LEVELS.INFO);
                                         {'csm': _mmmk.read()});
                                     manageHitchhiker(step['new_name']);
 
-                                    var csm = hitchhiker['csm'];
-                                    var _csm = eval('(' + csm + ')');
+                                    let csm = hitchhiker['csm'];
+                                    let _csm = eval('(' + csm + ')');
                                     if (step['insert']) {
-                                        var asoffset = parseInt(step['insert']),
-                                            csoffset = _mmmk.next_id,
-                                            incUri =
-                                                function (oldUri, offset) {
-                                                    var matches = oldUri.match(/(.+\/)(.+)(\.instance)/);
-                                                    return matches[1] +
-                                                        (parseInt(matches[2]) + offset) +
-                                                        matches[3];
-                                                };
+                                        let asoffset = parseInt(step['insert']);
+                                        let csoffset = _mmmk.next_id;
+                                        let incUri =
+                                            function (oldUri, offset) {
+                                                let matches = oldUri.match(/(.+\/)(.+)(\.instance)/);
+                                                return matches[1] +
+                                                    (parseInt(matches[2]) + offset) +
+                                                    matches[3];
+                                            };
 
-                                        for (var id in _csm.nodes) {
+                                        for (let id in _csm.nodes) {
                                             _csm.nodes[id]['$asuri']['value'] =
                                                 incUri(_csm.nodes[id]['$asuri']['value'],
                                                     asoffset);
@@ -504,15 +495,12 @@ logger.set_level(logger.LOG_LEVELS.INFO);
                                             if (!('$segments' in _csm.nodes[id]))
                                                 continue;
 
-                                            var segments =
-                                                    _csm.nodes[id]['$segments']['value'],
-                                                _segments = {};
-                                            for (var edgeId in segments) {
-                                                var uris = edgeId.match(
-                                                    /^(.*\.instance)--(.*\.instance)$/);
-                                                _segments[incUri(uris[1], csoffset) + '--' +
-                                                incUri(uris[2], csoffset)] =
-                                                    segments[edgeId];
+                                            let segments = _csm.nodes[id]['$segments']['value'];
+                                            let _segments = {};
+                                            for (let edgeId in segments) {
+                                                let uris = edgeId.match(/^(.*\.instance)--(.*\.instance)$/);
+                                                let seg = incUri(uris[1], csoffset) + '--' + incUri(uris[2], csoffset);
+                                                _segments[seg] = segments[edgeId];
                                             }
                                             _csm.nodes[id]['$segments']['value'] = _segments;
                                         }
@@ -522,18 +510,18 @@ logger.set_level(logger.LOG_LEVELS.INFO);
                                     //see if any cs metamodels are missing
                                     //this fixes issue #28
                                     //this loading should be done elsewhere in the model loading chain
-                                    for (var i in _csm.metamodels) {
-                                        var mm = _csm.metamodels[i];
+                                    for (let i in _csm.metamodels) {
+                                        let mm = _csm.metamodels[i];
 
                                         if (!(_mmmk.model.metamodels.includes(mm))) {
                                             logger.error("Last-minute loading for CS metamodel: " + mm);
 
-                                            var csmm = _fs.readFile('./users/' + mm, 'utf8');
+                                            let csmm = _fs.readFile('./users/' + mm, 'utf8');
                                             _mmmk.loadMetamodel(mm, csmm);
                                         }
                                     }
 
-                                    var res = _mmmk.loadModel(
+                                    let res = _mmmk.loadModel(
                                         step['new_name'],
                                         csm,
                                         step['insert']);
@@ -546,863 +534,848 @@ logger.set_level(logger.LOG_LEVELS.INFO);
                                     }
 
                                 });
-	
-						/* forward this SYSOUT command */
-						else if( step['op'] == 'SYSOUT' ) 
-							actions.push(
-								function()
-								{
-									cschangelogs.push([step]);
-									return __successContinuable();
-								});
-					});
 
-				actions.push(
-					function()
-					{
-						cschangelogs.push( self.__solveLayoutContraints(changelog) );
-						return __successContinuable();
-					});
-			}
+                        /* forward this SYSOUT command */
+                        else if (step['op'] == 'SYSOUT')
+                            actions.push(
+                                function () {
+                                    cschangelogs.push([step]);
+                                    return __successContinuable();
+                                });
+                    });
 
-			_do.chain(actions)(
-				function()
-				{
-					let cschangelog = _utils.flatten(cschangelogs);
-					let log_csc = _utils.jsons(_utils.collapse_changelog(cschangelog));
+                actions.push(
+                    function () {
+                        cschangelogs.push(self.__solveLayoutContraints(changelog));
+                        return __successContinuable();
+                    });
+            }
 
-					logger.debug('worker#'+__wid+' >> ('+aswSequenceNumber+') '+ log_csc);
+            _do.chain(actions)(
+                function () {
+                    let cschangelog = _utils.flatten(cschangelogs);
+                    let log_csc = _utils.jsons(_utils.collapse_changelog(cschangelog));
 
-					__postMessage(
-							{'statusCode':200,
-							 'changelog':cschangelog,
-	 						 'sequence#':aswSequenceNumber,
-							 'hitchhiker':cshitchhiker});
-					
-					self.__nextASWSequenceNumber = 
-						_utils.incrementSequenceNumber(self.__nextASWSequenceNumber);
-					self.__applyPendingASWChanges();
-				},
-				function(err) 
-				{
-					throw 'unexpected error while applying changelogs :: '+err;
-				}
-			);
-		},
+                    logger.debug('worker#' + __wid + ' >> (' + aswSequenceNumber + ') ' + log_csc);
+
+                    __postMessage(
+                        {
+                            'statusCode': 200,
+                            'changelog': cschangelog,
+                            'sequence#': aswSequenceNumber,
+                            'hitchhiker': cshitchhiker
+                        });
+
+                    self.__nextASWSequenceNumber =
+                        _utils.incrementSequenceNumber(self.__nextASWSequenceNumber);
+                    self.__applyPendingASWChanges();
+                },
+                function (err) {
+                    throw 'unexpected error while applying changelogs :: ' + err;
+                }
+            );
+        },
 
 
-	/* apply pending asworker changelogs, if any and if applicable */
-	'__applyPendingASWChanges' :
-		function()
-		{
-			if( this.__pendingChangelogs.length > 0 &&
-				 this.__nextASWSequenceNumber == 
-				 	this.__pendingChangelogs[0]['sequence#'] )
-				{
-					var pc = this.__pendingChangelogs.shift();
-					this.__applyASWChanges(
-							pc['changelog'],
-							pc['sequence#'],
-							pc['hitchhiker']);
-				}
-		},
+    /* apply pending asworker changelogs, if any and if applicable */
+    '__applyPendingASWChanges':
+        function () {
+            if (this.__pendingChangelogs.length > 0 &&
+                this.__nextASWSequenceNumber ==
+                this.__pendingChangelogs[0]['sequence#']) {
+                let pc = this.__pendingChangelogs.shift();
+                this.__applyASWChanges(
+                    pc['changelog'],
+                    pc['sequence#'],
+                    pc['hitchhiker']);
+            }
+        },
 
 
-	/* initialize a socket that will listen for and handle changelogs returned by
-	  	this csworker's associated asworker 
+    /* initialize a socket that will listen for and handle changelogs returned by
+          this csworker's associated asworker
 
-		1. onconnect() is triggered when 2 way communication is established, at
-	  		which point we attempt to subscribe for specified asworker
-		2. onmessage() is triggered once in response to our subscription attempt:
-				a) we set this.__aswid to specified aswid
-				b) if a cswid was provided (i.e., a shared model session is being
-					set up)
-						i.   retrieve the specified csworker's internal state 
-						ii.  setup this csworker's state and _mmmk based on the 
-							  results from step ii. 
-						iii. return the new state to the client (via callback())
-						iv.  remove any obsolete changelogs received since step i.
-							  and set __nextASWSequenceNumber to the same value as 
-							  that of the csworker whose state we're cloning
-						v.  apply pending changelogs, if any
-	  		all future triggers of onmessage() are due to the asworker pushing 
-			changelogs, these are handled by __applyASWChanges
-	 
-		NOTE : actually, there is a 3rd case where onmessage() is triggered...
-				 between the moment where the socket is created and the moment
-				 where we receive the response to our subscription attempt, we
-				 will receive *all* messages broadcasted by the websocket server
-				 in session_manager.js... these are detected and discarded */
-	'__aswSubscribe' :
-		function(aswid,cswid)
-		{
-			let self = this;
-			return function(callback,errback)
-			{
-				let io = _siocl('http://localhost:8124');
+        1. onconnect() is triggered when 2 way communication is established, at
+              which point we attempt to subscribe for specified asworker
+        2. onmessage() is triggered once in response to our subscription attempt:
+                a) we set this.__aswid to specified aswid
+                b) if a cswid was provided (i.e., a shared model session is being
+                    set up)
+                        i.   retrieve the specified csworker's internal state
+                        ii.  setup this csworker's state and _mmmk based on the
+                              results from step ii.
+                        iii. return the new state to the client (via callback())
+                        iv.  remove any obsolete changelogs received since step i.
+                              and set __nextASWSequenceNumber to the same value as
+                              that of the csworker whose state we're cloning
+                        v.  apply pending changelogs, if any
+              all future triggers of onmessage() are due to the asworker pushing
+            changelogs, these are handled by __applyASWChanges
 
-				io.on('connect',
-					function()
-					{
-						logger.http("socketio _ 'connect'" ,{'from':"/csworker"+__wid,'to': "/asworker"+aswid,'type':"-->>"});
-						logger.http("Sending changeListener to session_mngr for /asworker" + aswid + ".<br/>Below message comes from this worker", {'at':"/csworker"+__wid})
-						io.emit('message',
-							{'method':'POST','url':'/changeListener?wid='+aswid});
-					});
-				io.on('disconnect',
-					function()	{
-						logger.http("socketio _ 'disconnect'" ,{'from':"/asworker"+aswid,'to': "/csworker"+__wid,'type':"-->>"});
-						self.__aswid = undefined;
-					});
-				io.on('message',
-					function(msg)	
-					{
-						let log_statusCode = (msg.statusCode === undefined)? '': msg.statusCode + "<br/>";
+        NOTE : actually, there is a 3rd case where onmessage() is triggered...
+                 between the moment where the socket is created and the moment
+                 where we receive the response to our subscription attempt, we
+                 will receive *all* messages broadcasted by the websocket server
+                 in session_manager.js... these are detected and discarded */
+    '__aswSubscribe':
+        function (aswid, cswid) {
+            let self = this;
+            return function (callback, errback) {
+                let io = _siocl('http://localhost:8124');
 
-						/* on POST /changeListener response */
-						if( msg.statusCode !== undefined )
-						{
-							logger.http("socketio _ 'POST /changeListener resp' <br/> " + log_statusCode, {'from':"session_mngr",'to': "/csworker"+__wid,'type':"-->>"});
+                io.on('connect',
+                    function () {
+                        logger.http("socketio _ 'connect'", {
+                            'from': "/csworker" + __wid,
+                            'to': "/asworker" + aswid,
+                            'type': "-->>"
+                        });
+                        logger.http("Sending changeListener to session_mngr for /asworker" + aswid + ".<br/>Below message comes from this worker", {'at': "/csworker" + __wid})
+                        io.emit('message',
+                            {'method': 'POST', 'url': '/changeListener?wid=' + aswid});
+                    });
+                io.on('disconnect',
+                    function () {
+                        logger.http("socketio _ 'disconnect'", {
+                            'from': "/asworker" + aswid,
+                            'to': "/csworker" + __wid,
+                            'type': "-->>"
+                        });
+                        self.__aswid = undefined;
+                    });
+                io.on('message',
+                    function (msg) {
+                        let log_statusCode = (msg.statusCode === undefined) ? '' : msg.statusCode + "<br/>";
 
-							if( ! _utils.isHttpSuccessCode(msg.statusCode) )
-								return errback(msg.statusCode+':'+msg.reason);
-								
-							self.__aswid = aswid;	
-							if( cswid !== undefined )
-							{
-								let actions =
-										[__wHttpReq('GET','/internal.state?wid='+cswid)];
-								logger.http("http _ GET internal.state" ,{'from':"/csworker"+__wid,'to': "/csworker"+cswid,'type':"-)"});
-											
-								_do.chain(actions)(
-									function(respData) 		
-									{
-										var state = respData['data'];
-										_mmmk.clone(state['_mmmk']);
-										self.__clone(state['_wlib']);										
-										var __ids2uris = state['__ids2uris'];
-										set__ids2uris(__ids2uris);
-										var __nextSequenceNumber =
-												state['__nextSequenceNumber'];
-										set__nextSequenceNumber(__nextSequenceNumber);
-				
-										self.__pendingChangelogs = 
-											self.__pendingChangelogs.filter(
-												function(pc)
-												{
-													return self.__sn2int(pc['sequence#']) > 
-																self.__sn2int(
-																	self.__nextASWSequenceNumber)
-												});
-										callback();
-										self.__applyPendingASWChanges();
-									},
-									function(err) 	{errback(err);}
-								);
-							}
-							else
-								callback();
-						}
-	
-						/* on changelog reception (ignore changelogs while not 
-							subscribed to an asworker... see NOTE) */
-						else if( self.__aswid !== undefined ) {
-							let log_data = {};
-							if (msg.data) {
-								log_data = {'changelog': _utils.collapse_changelog(msg.data.changelog)};
-							}
-							logger.http("socketio _ 'recv chglg' <br/> " + log_statusCode + JSON.stringify(log_data),{'from':"/asworker"+aswid,'to': "/csworker"+__wid,'type':"-->>"});
-							self.__applyASWChanges(
-								msg.data.changelog,
-								msg.data['sequence#'],
-								msg.data.hitchhiker);
+                        /* on POST /changeListener response */
+                        if (msg.statusCode !== undefined) {
+                            logger.http("socketio _ 'POST /changeListener resp' <br/> " + log_statusCode, {
+                                'from': "session_mngr",
+                                'to': "/csworker" + __wid,
+                                'type': "-->>"
+                            });
 
-						}
-					});
-			};
-		},
+                            if (!_utils.isHttpSuccessCode(msg.statusCode))
+                                return errback(msg.statusCode + ':' + msg.reason);
+
+                            self.__aswid = aswid;
+                            if (cswid !== undefined) {
+                                let actions =
+                                    [__wHttpReq('GET', '/internal.state?wid=' + cswid)];
+                                logger.http("http _ GET internal.state", {
+                                    'from': "/csworker" + __wid,
+                                    'to': "/csworker" + cswid,
+                                    'type': "-)"
+                                });
+
+                                _do.chain(actions)(
+                                    function (respData) {
+                                        let state = respData['data'];
+                                        _mmmk.clone(state['_mmmk']);
+                                        self.__clone(state['_wlib']);
+                                        let __ids2uris = state['__ids2uris'];
+                                        set__ids2uris(__ids2uris);
+                                        let __nextSequenceNumber = state['__nextSequenceNumber'];
+                                        set__nextSequenceNumber(__nextSequenceNumber);
+
+                                        self.__pendingChangelogs =
+                                            self.__pendingChangelogs.filter(
+                                                function (pc) {
+                                                    return self.__sn2int(pc['sequence#']) >
+                                                        self.__sn2int(
+                                                            self.__nextASWSequenceNumber)
+                                                });
+                                        callback();
+                                        self.__applyPendingASWChanges();
+                                    },
+                                    function (err) {
+                                        errback(err);
+                                    }
+                                );
+                            } else
+                                callback();
+                        }
+
+                        /* on changelog reception (ignore changelogs while not
+                            subscribed to an asworker... see NOTE) */
+                        else if (self.__aswid !== undefined) {
+                            let log_data = {};
+                            if (msg.data) {
+                                log_data = {'changelog': _utils.collapse_changelog(msg.data.changelog)};
+                            }
+                            logger.http("socketio _ 'recv chglg' <br/> " + log_statusCode + JSON.stringify(log_data), {
+                                'from': "/asworker" + aswid,
+                                'to': "/csworker" + __wid,
+                                'type': "-->>"
+                            });
+                            self.__applyASWChanges(
+                                msg.data.changelog,
+                                msg.data['sequence#'],
+                                msg.data.hitchhiker);
+
+                        }
+                    });
+            };
+        },
 
 
+    /***************************** ICON GENERATION *****************************/
+    /* determine the correct positions and orientations of the given link's
+        decorators, adjust them and return changelogs
 
-	/***************************** ICON GENERATION *****************************/
-	/* determine the correct positions and orientations of the given link's 
-		decorators, adjust them and return changelogs 
-	 
-		0. concatenate segments into a single path
-		1. for each link decorator (i.e., Link $contents)
-			*. do nothing if link decoration information is missing... this ensures
-				backward compatibility with pre-link decorator models
-			a. extract link decoration information, i.e., xratio and yoffset
-			b. determine point on path at xratio and its orientation
-			c. adjust yoffset given orientation (yoffset was specified for 0deg)
-			d. adjust endAt given orientation (endAt is specified for 0deg)... note
-				that endAt is only relevant for arrowtails
-			e. relativize point from step b. w.r.t. to Link center and adjust 
-				position by adjusted yoffset
-			f. set new position and orientation in mmmk and remember changelogs
-		2. return flattened changelogs 
-	 
-		NOTE:: the initial values of vobject geometric attribute values must
-				 always be remembered... they are needed on the client to properly
-				 support the drawing and transformation of vobjects... this is 
-				 captured by buildVobjGeomAttrVal(), which we use in step 1f */
-	'__positionLinkDecorators' :
-		function(id)
-		{
-			var link	 		= _utils.jsonp(_mmmk.read(id)),
-				 vobjs 		= link['$contents']['value'].nodes,
-				 segments	= _utils.values(link['$segments']['value']),
-				 path			= segments[0]+
-					 				segments[1].substring(segments[1].indexOf('L')),
-				 changelogs = [];
+        0. concatenate segments into a single path
+        1. for each link decorator (i.e., Link $contents)
+            *. do nothing if link decoration information is missing... this ensures
+                backward compatibility with pre-link decorator models
+            a. extract link decoration information, i.e., xratio and yoffset
+            b. determine point on path at xratio and its orientation
+            c. adjust yoffset given orientation (yoffset was specified for 0deg)
+            d. adjust endAt given orientation (endAt is specified for 0deg)... note
+                that endAt is only relevant for arrowtails
+            e. relativize point from step b. w.r.t. to Link center and adjust
+                position by adjusted yoffset
+            f. set new position and orientation in mmmk and remember changelogs
+        2. return flattened changelogs
 
-			for( var vid in vobjs )
-			{
-				if( !('$linkDecoratorInfo' in vobjs[vid]) )
-					continue;
+        NOTE:: the initial values of vobject geometric attribute values must
+                 always be remembered... they are needed on the client to properly
+                 support the drawing and transformation of vobjects... this is
+                 captured by buildVobjGeomAttrVal(), which we use in step 1f */
+    '__positionLinkDecorators':
+        function (id) {
+            let link = _utils.jsonp(_mmmk.read(id));
+            let vobjs = link['$contents']['value'].nodes;
+            let segments = _utils.values(link['$segments']['value']);
+            let path = segments[0] + segments[1].substring(segments[1].indexOf('L'));
+            let changelogs = [];
 
-				var ldi 		= vobjs[vid]['$linkDecoratorInfo']['value'],
-					 pp  		= _svg.fns.getPointOnPathAtRatio(path,ldi.xratio);
-                     
+            for (let vid in vobjs) {
+                if (!('$linkDecoratorInfo' in vobjs[vid]))
+                    continue;
+
+                let ldi = vobjs[vid]['$linkDecoratorInfo']['value'];
+                let pp = _svg.fns.getPointOnPathAtRatio(path, ldi.xratio);
+
                 if (pp == undefined)
                     continue;
-                
-				var yoffset	= new _svg.types.Point(0,ldi.yoffset).rotate(pp.O),
-					endAt	= (ldi.xratio >= 1 ? 
-						 				new _svg.types.Point(100,0).rotate(pp.O) :
-										new _svg.types.Point(0,0)),
-					changes = {};
-				pp.x += yoffset.x - link['position']['value'][0];
-				pp.y += yoffset.y - link['position']['value'][1];
 
-				changes['$contents/value/nodes/'+vid+'/position'] 	  = 
-					[_utils.buildVobjGeomAttrVal(
-							vobjs[vid]['position']['value'][0], pp.x+','+endAt.x+'%'),
-					 _utils.buildVobjGeomAttrVal(
- 						  	vobjs[vid]['position']['value'][1], pp.y+','+endAt.y+'%')];
-				changes['$contents/value/nodes/'+vid+'/orientation'] = 
-					_utils.buildVobjGeomAttrVal(
-							vobjs[vid]['orientation']['value'],	pp.O);
-				changelogs.push( _mmmk.update(id,changes)['changelog'] );
-			}
+                let yoffset = new _svg.types.Point(0, ldi.yoffset).rotate(pp.O);
+                let endAt = (ldi.xratio >= 1 ?
+                    new _svg.types.Point(100, 0).rotate(pp.O) :
+                    new _svg.types.Point(0, 0));
+                let changes = {};
+                pp.x += yoffset.x - link['position']['value'][0];
+                pp.y += yoffset.y - link['position']['value'][1];
 
-			return _utils.flatten(changelogs);
-		},
+                changes['$contents/value/nodes/' + vid + '/position'] =
+                    [_utils.buildVobjGeomAttrVal(
+                        vobjs[vid]['position']['value'][0], pp.x + ',' + endAt.x + '%'),
+                        _utils.buildVobjGeomAttrVal(
+                            vobjs[vid]['position']['value'][1], pp.y + ',' + endAt.y + '%')];
+                changes['$contents/value/nodes/' + vid + '/orientation'] =
+                    _utils.buildVobjGeomAttrVal(
+                        vobjs[vid]['orientation']['value'], pp.O);
+                let chglg = _mmmk.update(id, changes)['changelog'];
+                changelogs.push(chglg);
+            }
 
-
-	/* regenerate specified icon... if newCsmm is specified, the regeneration 
-		process essentially transforms the icon for it to conform to whatever is
-	  	specified by newCsmm... otherwise, it merely involves re-evaluating
-	  	VisualObject mappers
-
-		1. if newCSmm is defined
-			a) create a new instance I of node 'id''s icontype given newCsmm
-			b) copy node 'id''s '$asuri', 'position', etc. attributes to I
-			c) delete node 'id'
-			d) update__asid2csid and 'id' variable to be I's id
-			e) save the changelogs of steps a-c)
-		2. in either case, [re-]eval VisualObject mappers
-			a) retrieve Icon and VisualObject mappers...
-				i.   fetch specified node from mmmk
-				ii.  retrieve its '$contents' attribute 
-				iii. retrieve the 'mapper' attribute for the node itself
-				iii. retrieve the 'mapper' attribute of VisualObjects within 
-					  '$contents'
-			b) return empty changelog if all mappers are empty
-			c) setup sync/async action chaining
-				i.  ask asworker to evaluate a bunch of mappers
-				ii. save results for later access
-			d) launch chain... 
-					on success, populate attributes with results from step 2ci and 
-					'return' changelog OR 'return' SYSOUT error if evaluating mappers
-					raised exceptions
-					on failure (this only occurs if we were unable to obtain an 
-					asworker read-lock), relaunch chain after short delay
-		TBI: step 2d) could potentially lead to an infinite loop if failure is due
-	  		  to unforeseen error or to very long delays if lock holder takes a 
-			  long time to finish... we could address this by *not* relaunching the
-			  chain if some number of tries have failed, and instead setting coded 
-			  attribute values to '<out-of-date>' */
-	'__regenIcon' :
-		function(id,newCsmm)
-		{
-			var changelogs = [],
- 				 self 	   = this;
-			return function(callback,errback)
-			{
-				if( newCsmm != undefined )
-				{
-					var node  = _utils.jsonp(_mmmk.read(id)),
-						 asuri = _mmmk.read(id,'$asuri'),
-						 asid	 = __uri_to_id(asuri),
-						 attrs = _utils.mergeDicts([
-									 {'$asuri':asuri,
-									  'position':node['position']['value'],
-									  'orientation':node['orientation']['value'],
-									  'scale':node['scale']['value']},
-									 ((s=_mmmk.read(id,'$segments'))['$err'] ?
-										 {} : {'$segments':s}) ]),
-						 cres  = _mmmk.create(
-								 		newCsmm+'/'+node['$type'].match(/.*\/(.*)/)[1],
-										attrs),
-						 csid	 = cres['id'],
-						 dres	 = _mmmk['delete'](id);
-					 self.__asid2csid[asid] = id = csid;
-					 changelogs.push(
-							 cres['changelog'],
-							 dres['changelog']);
-				}
-
-				var csuri  	 		= __id_to_uri(id),
-					 asuri			= self.__csuri_to_asuri(csuri),
-					 icon				= _utils.jsonp(_mmmk.read(id)),
-					 vobjects		= icon['$contents']['value'],
-					 mappers 		= {};
-
-				if( icon['mapper']['value'] != '' )
-					mappers[''] = icon['mapper']['value'];
-
-				for( var vid in vobjects['nodes'] )
-					if( 'mapper' in vobjects['nodes'][vid] &&
-						 vobjects['nodes'][vid]['mapper']['value'] != '' )
-						mappers['$contents/value/nodes/'+vid+'/'] = 
-							vobjects['nodes'][vid]['mapper']['value'];
-
-				if( _utils.keys(mappers).length > 0 )
-				{
-					var actions =
-							[__wHttpReq(
-									'POST',
-									'/GET/'+asuri+'.mappings?wid='+self.__aswid,
-									mappers)],
-						 successf = 
- 							 function(attrVals)
- 							 {
-								 if( '$err' in attrVals )
-									 callback( 
-										[{'op':'SYSOUT',
-										  'text':'ERROR :: '+attrVals['$err']}]);
-								 else
-								 {
-									 var changes = {};
-	 								 for( var fullattr in attrVals )
-	 									 changes[fullattr] = attrVals[fullattr];
-                                     var result = _mmmk.update(id,changes);
-                                     if ( '$err' in result )
-                                         callback( 
-                                            [{'op':'SYSOUT',
-                                              'text':'ERROR :: '+result['$err']}]);
-                                     else {
-                                         changelogs.push(
-                                                 result['changelog'] );
-                                         callback( _utils.flatten(changelogs) );
-                                     }
-								 }
- 							 },
-						 failuref = 
-	 						 function(err) 
-	 						 {
-	 							 logger.error('"POST *.mappings" failed on :: '+err+
-										 		'\n(will try again soon)');
-	 							 setTimeout(
-		 								 _do.chain(actions),
-		 								 self.__REGEN_ICON_RETRY_DELAY_MS,
-		 								 successf,
-		 								 failuref);
-	 						 };
-					_do.chain(actions)(successf,failuref);
-				}
-				else
-					callback( _utils.flatten(changelogs) );
-			};
-		},
+            return _utils.flatten(changelogs);
+        },
 
 
-	'__solveLayoutContraints':
-		function(changelog)
-		{
-			// TBC actually implement this function 
-			//	use ids in changelog to determine what changed 
-			//	add 2 lines below to mmmk.__create() if necessary
-			//		if( type in this.metamodels[metamodel]['connectorTypes'] )
-			//			new_node['$linktype'] = this.metamodels[metamodel]['connectorTypes'][type];	
+    /* regenerate specified icon... if newCsmm is specified, the regeneration
+        process essentially transforms the icon for it to conform to whatever is
+          specified by newCsmm... otherwise, it merely involves re-evaluating
+          VisualObject mappers
 
-			return [];
-			// return [{'op':'SYSOUT',
-			//   		  'text':'WARNING :: '+
-			// 			  		'a proper layout constraint solver has yet to be '+
-			// 			  		'implemented... inter-VisualObject relationships are '+
-			// 					'ignored and containers do not resize to fit their '+
-			// 					'contents'}];
-		},
+        1. if newCSmm is defined
+            a) create a new instance I of node 'id''s icontype given newCsmm
+            b) copy node 'id''s '$asuri', 'position', etc. attributes to I
+            c) delete node 'id'
+            d) update__asid2csid and 'id' variable to be I's id
+            e) save the changelogs of steps a-c)
+        2. in either case, [re-]eval VisualObject mappers
+            a) retrieve Icon and VisualObject mappers...
+                i.   fetch specified node from mmmk
+                ii.  retrieve its '$contents' attribute
+                iii. retrieve the 'mapper' attribute for the node itself
+                iii. retrieve the 'mapper' attribute of VisualObjects within
+                      '$contents'
+            b) return empty changelog if all mappers are empty
+            c) setup sync/async action chaining
+                i.  ask asworker to evaluate a bunch of mappers
+                ii. save results for later access
+            d) launch chain...
+                    on success, populate attributes with results from step 2ci and
+                    'return' changelog OR 'return' SYSOUT error if evaluating mappers
+                    raised exceptions
+                    on failure (this only occurs if we were unable to obtain an
+                    asworker read-lock), relaunch chain after short delay
+        TBI: step 2d) could potentially lead to an infinite loop if failure is due
+                to unforeseen error or to very long delays if lock holder takes a
+              long time to finish... we could address this by *not* relaunching the
+              chain if some number of tries have failed, and instead setting coded
+              attribute values to '<out-of-date>' */
+    '__regenIcon':
+        function (id, newCsmm) {
+            let changelogs = [];
+            let self = this;
+            return function (callback, errback) {
+                if (newCsmm != undefined) {
+                    let node = _utils.jsonp(_mmmk.read(id));
+                    let asuri = _mmmk.read(id, '$asuri');
+                    let asid = __uri_to_id(asuri);
 
+                    let dict1 = {
+                        '$asuri': asuri,
+                        'position': node['position']['value'],
+                        'orientation': node['orientation']['value'],
+                        'scale': node['scale']['value']
+                    };
+                    let s = _mmmk.read(id, '$segments');
+                    let dict2 = {};
+                    if (s['$err'] == undefined)
+                        dict2 = {'$segments': s}
+                    let attrs = _utils.mergeDicts([dict1, dict2]);
 
-	/* transform all icons from tgtCsmm into appropriate icons of newCsmm
-	
-		1. read model and newCsmm from _mmmk
-		2. for each icon of tgtCsmm, if newCsmm defines a replacement icon, save
-			the icon's id in 'tgtIds'... otherwise, return error 
-		3. init sync/async action chaining... 
-			a) for each id in 'tgtIds', add 2 entries to chain
-				i.  call __regenIcon on specified icon
-				ii. save resulting changelog and continue 
-		4. launch chain... 
-			on success, 
-				a) adjust $segments attributes from all Links to account for edge
-					end change of id (and uri)
-				b) 'return' flattened changelogs
-			on failure, 'return' error */
-	'__transformIcons' :
-		function(tgtCsmm,newCsmm)
-		{
-			var self = this;
-			return function(callback,errback)
-			{
-				var m 			 = _utils.jsonp(_mmmk.read()),
-					 newCsmmData = _utils.jsonp(_mmmk.readMetamodels(newCsmm)),
-					 tgtIds		 = [],
-					 newIds		 = {},
-					 changelogs  = [],
-					 actions	    = [__successContinuable()];
+                    let cres = _mmmk.create(
+                        newCsmm + '/' + node['$type'].match(/.*\/(.*)/)[1],
+                        attrs);
+                    let csid = cres['id'];
+                    let dres = _mmmk['delete'](id);
+                    self.__asid2csid[asid] = id = csid;
+                    changelogs.push(
+                        cres['changelog'],
+                        dres['changelog']);
+                }
 
-				for( var id in m.nodes )
-					if( (matches = m.nodes[id]['$type'].match('^'+tgtCsmm+'/(.*)')) )
-					{
-						var type = matches[1];
-						if( newCsmmData.types[type] == undefined )
-						{
-							errback('Icons mm should define type :: '+type);
-							return;
-						}
-						tgtIds.push(id);
-					}
+                let csuri = __id_to_uri(id);
+                let asuri = self.__csuri_to_asuri(csuri);
+                let icon = _utils.jsonp(_mmmk.read(id));
+                let vobjects = icon['$contents']['value'];
+                let mappers = {};
 
-				tgtIds.forEach(
-					function(id) 
-					{
-						actions.push(
-							function()	{return self.__regenIcon(id,newCsmm);},
-							function(changelog)	
-							{
-								var newId = changelog[0]['id'];
-								newIds[id] = newId;		
-								changelogs.push(
-									changelog.concat(
-										'$err' in _mmmk.read(newId,'$segments') ?
-											[] : self.__positionLinkDecorators(newId)) );
-								return __successContinuable();
-							});
-					});
-				
-				_do.chain(actions)(
-					function()	  
-					{
-						var m = _utils.jsonp(_mmmk.read());
-						for( var id in m.nodes )
-							if( (matches = m.nodes[id]['$type'].match(/Link$/)) )
-							{
-								var s			= _mmmk.read(id,'$segments'),
-									 changed	= false;
-								for( var edgeId in s )
-								{
-									var ends = 
-											edgeId.match(/(.*\.instance)--(.*\.instance)/),
-										 id1	= __uri_to_id(ends[1]),
-										 id2	= __uri_to_id(ends[2]);
- 
-									if( id1 in newIds )
-									{
-										ends[1] = __id_to_uri( newIds[id1] );
-			 							changed = true;
-	 								}
-									if( id2 in newIds )
-									{
-										ends[2] = __id_to_uri( newIds[id2] );
-										changed = true;
-									}
-									if( changed )
-									{
-										s[ends[1]+'--'+ends[2]] = s[edgeId];
-										delete s[edgeId];
-									}
-								}
-								if( changed )
-									changelogs.push( 
-										_mmmk.update(id,{'$segments':s})['changelog'] );
-							}
+                if (icon['mapper']['value'] != '')
+                    mappers[''] = icon['mapper']['value'];
 
-						callback(_utils.flatten(changelogs));
-					},
-					function(err) 
-					{
-						errback('__transformIcons() should never fail... '+
-								  'failed on :: '+err); 
-					}
-				);
-			};
-		},
+                for (let vid in vobjects['nodes'])
+                    if ('mapper' in vobjects['nodes'][vid] && vobjects['nodes'][vid]['mapper']['value'] != '')
+                        mappers['$contents/value/nodes/' + vid + '/'] = vobjects['nodes'][vid]['mapper']['value'];
 
-
-
-	/************************** REST REQUEST HANDLING **************************/
-	/* INTENT :
-			ask our asworker's mtworker to do something (e.g., change 
-			transformation execution mode) 
-		IN PRACTICE: 
-			adjust uri and forward to asworker
-
-	1. setup sync/async action chaining
-		a) ask asworker to forward request to its mtworker
-	2. launch chain... return success code or error */
-	'mtwRequest' :
-		function(resp,method,uri,reqData)
-		{
-			var actions = [__wHttpReq(
-									method,
-									uri+'?wid='+this.__aswid,
-									reqData)];
-
-			_do.chain(actions)(
-					function() 
-					{
-						__postMessage({'statusCode':200, 'respIndex':resp});
-					},
-					function(err) 	{__postInternalErrorMsg(resp,err);}
-			);
-		},
+                if (_utils.keys(mappers).length > 0) {
+                    let actions =
+                        [__wHttpReq(
+                            'POST',
+                            '/GET/' + asuri + '.mappings?wid=' + self.__aswid,
+                            mappers)];
+                    let successf =
+                        function (attrVals) {
+                            if ('$err' in attrVals)
+                                callback(
+                                    [{
+                                        'op': 'SYSOUT',
+                                        'text': 'ERROR :: ' + attrVals['$err']
+                                    }]);
+                            else {
+                                let changes = {};
+                                for (let fullattr in attrVals)
+                                    changes[fullattr] = attrVals[fullattr];
+                                let result = _mmmk.update(id, changes);
+                                if ('$err' in result)
+                                    callback(
+                                        [{
+                                            'op': 'SYSOUT',
+                                            'text': 'ERROR :: ' + result['$err']
+                                        }]);
+                                else {
+                                    changelogs.push(
+                                        result['changelog']);
+                                    callback(_utils.flatten(changelogs));
+                                }
+                            }
+                        };
+                    let failuref =
+                        function (err) {
+                            logger.error('"POST *.mappings" failed on :: ' + err +
+                                '\n(will try again soon)');
+                            setTimeout(
+                                _do.chain(actions),
+                                self.__REGEN_ICON_RETRY_DELAY_MS,
+                                successf,
+                                failuref);
+                        };
+                    _do.chain(actions)(successf, failuref);
+                } else
+                    callback(_utils.flatten(changelogs));
+            };
+        },
 
 
-	/*	return sufficient information to clone the current csworker to the tinyest
-	   detail... this is a pimped out version of GET current.state for internal
-		use only
-		1. bundle info about _mmmk and _wlib
-		2. return to querier */			
-	'GET /internal.state' :
-		function(resp)
-		{
-			__postMessage(
-					{'statusCode':200,
-					 'data':{'_mmmk':_mmmk.clone(),
-	 						   '_wlib':this.__clone(),
-								'__ids2uris':_utils.clone(get__ids2uris()),
-								'__nextSequenceNumber':get__nextSequenceNumber()},
-					 'sequence#':__sequenceNumber(0),
-					 'respIndex':resp});
-		},
-		
+    '__solveLayoutContraints':
+        function (changelog) {
+            // TBC actually implement this function
+            //	use ids in changelog to determine what changed
+            //	add 2 lines below to mmmk.__create() if necessary
+            //		if( type in this.metamodels[metamodel]['connectorTypes'] )
+            //			new_node['$linktype'] = this.metamodels[metamodel]['connectorTypes'][type];
 
-	/* subscribe to an existing or to-be-created asworker
+            return [];
+            // return [{'op':'SYSOUT',
+            //   		  'text':'WARNING :: '+
+            // 			  		'a proper layout constraint solver has yet to be '+
+            // 			  		'implemented... inter-VisualObject relationships are '+
+            // 					'ignored and containers do not resize to fit their '+
+            // 					'contents'}];
+        },
 
-		1. validate parameters 
-		2. if 'aswid' and 'cswid' are given,
-			a) setup sync/async action chaining
-				i) attempt to subsribe to specified asworker using specified 
-					csworker's current model as this csworker's initial model
-			b) launch chain... on success, 'return' current state (via 
-				GET__current_state())... on error, return error
-		2. otherwise,
-			a) setup sync/async action chaining
-				i)  spawn new asworker
-				ii) subscribe to it
-			b) launch chain... return success code or error */
-	'PUT /aswSubscription' :
-		function(resp,uri,reqData/*wid*/)
-		{
-		  	if( this.__aswid > -1 )
-				return __postForbiddenErrorMsg(
-						resp,
-						'already subscribed to an asworker');
 
-			if( reqData != undefined )
-			{
-				if( reqData['aswid'] == undefined ||
-					 reqData['cswid'] == undefined )
-					return __postInternalErrorMsg(resp, 'missing AS and/or CS wid');
+    /* transform all icons from tgtCsmm into appropriate icons of newCsmm
 
-				logger.info("/csworker" + __wid + " attaching to /asworker" + reqData['aswid'] + " and cloning /csworker" + reqData['cswid']);
-				let actions = [this.__aswSubscribe(reqData['aswid'],reqData['cswid'])];
-		
-				_do.chain(actions)(
-						function() 
-						{
-							GET__current_state(resp);
-						},
-						function(err) 	{__postInternalErrorMsg(resp,err);}
-				);
-			}
+        1. read model and newCsmm from _mmmk
+        2. for each icon of tgtCsmm, if newCsmm defines a replacement icon, save
+            the icon's id in 'tgtIds'... otherwise, return error
+        3. init sync/async action chaining...
+            a) for each id in 'tgtIds', add 2 entries to chain
+                i.  call __regenIcon on specified icon
+                ii. save resulting changelog and continue
+        4. launch chain...
+            on success,
+                a) adjust $segments attributes from all Links to account for edge
+                    end change of id (and uri)
+                b) 'return' flattened changelogs
+            on failure, 'return' error */
+    '__transformIcons':
+        function (tgtCsmm, newCsmm) {
+            let self = this;
+            return function (callback, errback) {
+                let m = _utils.jsonp(_mmmk.read());
+                let newCsmmData = _utils.jsonp(_mmmk.readMetamodels(newCsmm));
+                let tgtIds = [];
+                let newIds = {};
+                let changelogs = [];
+                let actions = [__successContinuable()];
 
-			else
-			{
-				logger.http("/csworker" + __wid + " creating /asworker", {'at': '/csworker'+__wid});
+                for (let id in m.nodes) {
+                    let matches = m.nodes[id]['$type'].match('^' + tgtCsmm + '/(.*)')
+                    if (matches) {
+                        let type = matches[1];
+                        if (newCsmmData.types[type] == undefined) {
+                            errback('Icons mm should define type :: ' + type);
+                            return;
+                        }
+                        tgtIds.push(id);
+                    }
+                }
+                tgtIds.forEach(
+                    function (id) {
+                        actions.push(
+                            function () {
+                                return self.__regenIcon(id, newCsmm);
+                            },
+                            function (changelog) {
+                                let newId = changelog[0]['id'];
+                                newIds[id] = newId;
 
-				let self = this;
-				let actions = [
+                                let chglg = _mmmk.read(newId, '$segments');
+                                changelogs.push(
+                                    changelog.concat(
+                                        '$err' in chglg ? [] : self.__positionLinkDecorators(newId)));
+                                return __successContinuable();
+                            });
+                    });
+
+                _do.chain(actions)(
+                    function () {
+                        let m = _utils.jsonp(_mmmk.read());
+                        for (let id in m.nodes) {
+                            let matches = m.nodes[id]['$type'].match(/Link$/);
+                            if (matches) {
+                                let s = _mmmk.read(id, '$segments');
+                                let changed = false;
+                                for (let edgeId in s) {
+                                    let ends = edgeId.match(/(.*\.instance)--(.*\.instance)/);
+                                    let id1 = __uri_to_id(ends[1]);
+                                    let id2 = __uri_to_id(ends[2]);
+
+                                    if (id1 in newIds) {
+                                        ends[1] = __id_to_uri(newIds[id1]);
+                                        changed = true;
+                                    }
+                                    if (id2 in newIds) {
+                                        ends[2] = __id_to_uri(newIds[id2]);
+                                        changed = true;
+                                    }
+                                    if (changed) {
+                                        s[ends[1] + '--' + ends[2]] = s[edgeId];
+                                        delete s[edgeId];
+                                    }
+                                }
+                                if (changed)
+                                    changelogs.push(
+                                        _mmmk.update(id, {'$segments': s})['changelog']);
+                            }
+                        }
+
+                        callback(_utils.flatten(changelogs));
+                    },
+                    function (err) {
+                        errback('__transformIcons() should never fail... ' +
+                            'failed on :: ' + err);
+                    }
+                );
+            };
+        },
+
+
+    /************************** REST REQUEST HANDLING **************************/
+    /* INTENT :
+            ask our asworker's mtworker to do something (e.g., change
+            transformation execution mode)
+        IN PRACTICE:
+            adjust uri and forward to asworker
+
+    1. setup sync/async action chaining
+        a) ask asworker to forward request to its mtworker
+    2. launch chain... return success code or error */
+    'mtwRequest':
+        function (resp, method, uri, reqData) {
+            let actions = [__wHttpReq(method, uri + '?wid=' + this.__aswid, reqData)];
+
+            _do.chain(actions)(
+                function () {
+                    __postMessage({'statusCode': 200, 'respIndex': resp});
+                },
+                function (err) {
+                    __postInternalErrorMsg(resp, err);
+                }
+            );
+        },
+
+
+    /*	return sufficient information to clone the current csworker to the tinyest
+       detail... this is a pimped out version of GET current.state for internal
+        use only
+        1. bundle info about _mmmk and _wlib
+        2. return to querier */
+    'GET /internal.state':
+        function (resp) {
+            __postMessage(
+                {
+                    'statusCode': 200,
+                    'data': {
+                        '_mmmk': _mmmk.clone(),
+                        '_wlib': this.__clone(),
+                        '__ids2uris': _utils.clone(get__ids2uris()),
+                        '__nextSequenceNumber': get__nextSequenceNumber()
+                    },
+                    'sequence#': __sequenceNumber(0),
+                    'respIndex': resp
+                });
+        },
+
+
+    /* subscribe to an existing or to-be-created asworker
+
+        1. validate parameters
+        2. if 'aswid' and 'cswid' are given,
+            a) setup sync/async action chaining
+                i) attempt to subsribe to specified asworker using specified
+                    csworker's current model as this csworker's initial model
+            b) launch chain... on success, 'return' current state (via
+                GET__current_state())... on error, return error
+        2. otherwise,
+            a) setup sync/async action chaining
+                i)  spawn new asworker
+                ii) subscribe to it
+            b) launch chain... return success code or error */
+    'PUT /aswSubscription':
+        function (resp, uri, reqData/*wid*/) {
+            if (this.__aswid > -1)
+                return __postForbiddenErrorMsg(resp, 'already subscribed to an asworker');
+
+            if (reqData != undefined) {
+                if (reqData['aswid'] == undefined ||
+                    reqData['cswid'] == undefined)
+                    return __postInternalErrorMsg(resp, 'missing AS and/or CS wid');
+
+                logger.info("/csworker" + __wid + " attaching to /asworker" + reqData['aswid'] + " and cloning /csworker" + reqData['cswid']);
+                let actions = [this.__aswSubscribe(reqData['aswid'], reqData['cswid'])];
+
+                _do.chain(actions)(
+                    function () {
+                        GET__current_state(resp);
+                    },
+                    function (err) {
+                        __postInternalErrorMsg(resp, err);
+                    }
+                );
+            } else {
+                logger.http("/csworker" + __wid + " creating /asworker", {'at': '/csworker' + __wid});
+
+                let self = this;
+                let actions = [
                     __httpReq("POST", "/asworker"),
                     function (aswid) {
                         logger.http(
-                            "/csworker" + __wid + " subscribing to /asworker" + aswid, {'at': '/csworker'+__wid});
+                            "/csworker" + __wid + " subscribing to /asworker" + aswid, {'at': '/csworker' + __wid});
                         return self.__aswSubscribe(aswid);
                     },
                 ];
-		
-				_do.chain(actions)(
-						function() 
-						{
-							__postMessage(
-								{'statusCode':200, 
-								 'data':self.__aswid,
-								 'respIndex':resp});
-						},
-						function(err) 	{__postInternalErrorMsg(resp,err);}
-				);
-			}
-		},
 
-	
-	/* INTENT : 
-			load a CS and an AS metamodel from disk
-	 			*OR* 
-			switch between different CS metamodels
-		IN PRACTICE: 
-			adjust uri and reqData and forward to asworker
-	 			*OR* 
-			fulfill intent				
-
-		1.	parse + validate parameters
-		2. if no asmm is specified (CS switch),
-			a) setup sync/async action chaining
-				i.   read specified csmm from disk
-				ii.  load read data into _mmmk
-				iii. try to regen all icons from overwritten csmm
-			b) launch chain... 
-				i.  on failure, undo step 2.a)ii. if it ran, and return error
-				ii. on success, 
-					j.   return success code
-				   jj.  unload previous csmm
-					jjj. post bundled and flattened changelogs
-		2. if an asmm is specified (MM load)
-			a) setup sync/async action chaining
-				i.  read specified csmm from disk
-				ii. ask asworker to load AS metamodel + pass CS metamodel name and
-			  		 data as 'hitchhiker'
-			b) launch chain... return success code or error */
-	'PUT /current.metamodels' :
-		function(resp,uri,reqData/*[asmm,]csmm*/)
-		{
-			if( reqData == undefined )
-				return __postBadReqErrorMsg(resp, 'missing request data');
-			else if( reqData['csmm'] == undefined )
-				return __postBadReqErrorMsg(resp, 'missing CS mm');
-			else if( ! (matches = reqData['csmm'].
-							match(/.+?((\/.*)\..*Icons(\.pattern){0,1})\.metamodel/)) )
-				return __postBadReqErrorMsg(
-								resp,
-								'bad uri for Icons mm :: '+reqData['csmm']);
-
-			var asmm = matches[2]+(matches[3] || ''),
-				 csmm = matches[1];
-
-			if( reqData['asmm'] == undefined )
-			{
-				if( this.__asmm2csmm[asmm] == undefined )
-					return __postBadReqErrorMsg(resp, 'missing AS mm');
-
-				var lres		= undefined,
-					 sn		= undefined,
-					 self		= this,
-					 actions = 
-						 [_fs.readFile('./users'+reqData['csmm'],'utf8'),
-					 	  function(csmmData)
-						  {
-							  sn 	 = __sequenceNumber();
-			  				  self.__checkpointUserOperation(sn); 
-							  lres = _mmmk.loadMetamodel(csmm,csmmData);
-							  return __successContinuable();
-						  },
-						  function()	
-						  {
-							  return self.__transformIcons(
-									  					self.__asmm2csmm[asmm],
-									  					csmm);
-						  }];
-
-				_do.chain(actions)(
-						function(changelog) 
-						{
-							__postMessage({'statusCode':202, 'respIndex':resp});
-
-							var ures = _mmmk.unloadMetamodel(self.__asmm2csmm[asmm]),
-								 changelogs = 
-								 	[lres['changelog'],changelog,ures['changelog']];
-							self.__asmm2csmm[asmm] = csmm;
-
-							__postMessage(
-								{'statusCode':200,
-  								 'changelog':_utils.flatten(changelogs),
-								 'sequence#':sn});
-						},
-						function(err) 	
-						{
-							if( sn != undefined )
-								__postInternalErrorMsg(resp,
-									'CS switch should never fail for non-I/O reason'+
-									'... backend may now be in unstable state... '+
-									'failed on :: '+err);
-							else
-								__postInternalErrorMsg(resp,err);
-						}
-				);
-			}
-			else
-			{	
-				var self = this,
-					actions = 
-	 					[_fs.readFile('./users'+reqData['csmm'],'utf8'),
-					 	function(csmmData)
-						{
-							return __wHttpReq(
-								'PUT',
-								uri+'?wid='+self.__aswid,
-								{'mm':reqData['asmm'],
-  								'hitchhiker':{'csmm':csmmData,'name':csmm}});
-						  }];
-
-				_do.chain(actions)(
-						function() 
-						{
-							__postMessage({'statusCode':202, 'respIndex':resp});
-						},
-						function(err) 	{__postInternalErrorMsg(resp,err);}
-				);
-			}
-		},
-
-
-	/*  INTENT : 
-			unload a metamodel (deletes all entities from that metamodel)
-		IN PRACTICE: 
-			adjust uri and forward to asworker
- 
-		1. parse + validate parameters
-		2. setup sync/async action chaining
-			a) ask asworker to unload corresponding AS mm
-		3. launch chain... on success, unload specified metamodel */
-	'DELETE *.metamodel' :
-		function(resp,uri)
-		{
-			var matches = uri.match(/(.*)\..*Icons(\.pattern){0,1}\.metamodel/);			
-			if( ! matches )
-				return __postBadReqErrorMsg(resp,'bad uri for Icons mm :: '+uri);
-
-			var asuri   = matches[1]+(matches[2] || '')+'.metamodel',
-				 actions = 
-					 [__wHttpReq('DELETE',asuri+'?wid='+this.__aswid)];
-
-			_do.chain(actions)(
-					function() 
-					{
-						__postMessage({'statusCode':202, 'respIndex':resp});
-					},
-					function(err) 	{__postInternalErrorMsg(resp,err);}
-			);
-		},
-
-
-	/*  INTENT : 
-	  		load a model from disk
-				OR
-			clear current model (and metamodels)
-		IN PRACTICE: 
-			adjust reqData and forward to asworker
-
-		1. parse + validate parameters
-		2. read specified model from disk
-				OR
-			fabricate empty model
-		3. setup sync/async action chaining
-			a) ask asworker to load associated AS model + pass CS model as 
-				'hitchhiker'
-		4. launch chain... return success code or error */
-	'PUT /current.model' :
-		function(resp,uri,reqData/*m[,insert]*/)
-		{
-			if( reqData == undefined )
-				return __postBadReqErrorMsg(resp, 'missing model');
-
-			var self	 	= this,
-				 mData	= undefined,
-				 actions = [];
-			if( reqData['m'] == undefined )
-				 actions = 
-					 [__successContinuable(),
-					  function()
- 					  {
-						  mData = {"csm": {"nodes": {},
-											    "edges": [],
-												 "metamodels": []},
-									  "asm": {"nodes": {},
- 												 "edges": [],
-												 "metamodels": []}};
-						  reqData['m'] = 'new';
-						  return __successContinuable(mData);
-					  }];
-			else {
-                try {
-                    _fs.accessSync('./users/'+reqData['m']);
-                } catch (e) {
-                    return __postBadReqErrorMsg(resp, 'cannot read ' + reqData['m']);
-                }
-                actions = [   _fs.readFile('./users/'+reqData['m'],'utf8'),
-                              function(_mData)
-                              {
-                                  mData = eval('('+_mData+')');
-                                  return __successContinuable(mData);
-                              }];
-                actions.push(
-                    function(m)
-                    {
-                        var asmData = _utils.jsons(m['asm']),
-                              csmData = _utils.jsons(m['csm']);
-						return __wHttpReq(
-                            'PUT',
-                            uri+'?wid='+self.__aswid,
-                            {'m':asmData,
-                            'name':reqData['m']+(new Date().getTime()),
-                            'insert':reqData['insert'],
-                            'hitchhiker':{'csm':csmData}});						
-                    });
                 _do.chain(actions)(
-                    function() 
-                    {
-                        __postMessage({'statusCode':202,'respIndex':resp});					
+                    function () {
+                        __postMessage(
+                            {
+                                'statusCode': 200,
+                                'data': self.__aswid,
+                                'respIndex': resp
+                            });
                     },
-                    function(err) 	
-                    {
-                        var MISSING_MM_ERROR = 'metamodel not loaded :: ';
-                        if( (matches = err.match('^500:'+MISSING_MM_ERROR+
-                                                                    '(.*?)(\\.pattern){0,1}$')) )
-                        {
-                            var asmm = matches[1],
-                                 pmm	= (matches[2] != undefined),
-                                 csmm;
-                            mData['csm'].metamodels.some(
-                                function(mm)
-                                {
-                                    if( (pmm && mm.match(
-                                            '^'+asmm+'\\.[a-zA-Z0-9]*Icons\\.pattern$')) ||
-                                         (!pmm && mm.match(
-                                            '^'+asmm+'\\.[a-zA-Z0-9]*Icons$')) )
-                                        csmm = mm;
-                                    return csmm;
-                                });
-                            __postInternalErrorMsg(resp,MISSING_MM_ERROR+csmm);
-                        }
-                        else
-                            __postInternalErrorMsg(resp,err);
+                    function (err) {
+                        __postInternalErrorMsg(resp, err);
                     }
                 );
             }
-		},
+        },
+
+
+    /* INTENT :
+            load a CS and an AS metamodel from disk
+                 *OR*
+            switch between different CS metamodels
+        IN PRACTICE:
+            adjust uri and reqData and forward to asworker
+                 *OR*
+            fulfill intent
+
+        1.	parse + validate parameters
+        2. if no asmm is specified (CS switch),
+            a) setup sync/async action chaining
+                i.   read specified csmm from disk
+                ii.  load read data into _mmmk
+                iii. try to regen all icons from overwritten csmm
+            b) launch chain...
+                i.  on failure, undo step 2.a)ii. if it ran, and return error
+                ii. on success,
+                    j.   return success code
+                   jj.  unload previous csmm
+                    jjj. post bundled and flattened changelogs
+        2. if an asmm is specified (MM load)
+            a) setup sync/async action chaining
+                i.  read specified csmm from disk
+                ii. ask asworker to load AS metamodel + pass CS metamodel name and
+                       data as 'hitchhiker'
+            b) launch chain... return success code or error */
+    'PUT /current.metamodels':
+        function (resp, uri, reqData/*[asmm,]csmm*/) {
+            if (reqData == undefined)
+                return __postBadReqErrorMsg(resp, 'missing request data');
+            else if (reqData['csmm'] == undefined)
+                return __postBadReqErrorMsg(resp, 'missing CS mm');
+
+            let matches = reqData['csmm'].match(/.+?((\/.*)\..*Icons(\.pattern){0,1})\.metamodel/);
+            if (!matches)
+                return __postBadReqErrorMsg(resp, 'bad uri for Icons mm :: ' + reqData['csmm']);
+
+            let asmm = matches[2] + (matches[3] || '');
+            let csmm = matches[1];
+
+            if (reqData['asmm'] == undefined) {
+                if (this.__asmm2csmm[asmm] == undefined)
+                    return __postBadReqErrorMsg(resp, 'missing AS mm');
+
+                let lres = undefined;
+                let sn = undefined;
+                let self = this;
+                let actions =
+                    [_fs.readFile('./users' + reqData['csmm'], 'utf8'),
+                        function (csmmData) {
+                            sn = __sequenceNumber();
+                            self.__checkpointUserOperation(sn);
+                            lres = _mmmk.loadMetamodel(csmm, csmmData);
+                            return __successContinuable();
+                        },
+                        function () {
+                            return self.__transformIcons(
+                                self.__asmm2csmm[asmm],
+                                csmm);
+                        }];
+
+                _do.chain(actions)(
+                    function (changelog) {
+                        __postMessage({'statusCode': 202, 'respIndex': resp});
+
+                        let ures = _mmmk.unloadMetamodel(self.__asmm2csmm[asmm]);
+                        let changelogs = [lres['changelog'], changelog, ures['changelog']];
+                        self.__asmm2csmm[asmm] = csmm;
+
+                        __postMessage(
+                            {
+                                'statusCode': 200,
+                                'changelog': _utils.flatten(changelogs),
+                                'sequence#': sn
+                            });
+                    },
+                    function (err) {
+                        if (sn != undefined)
+                            __postInternalErrorMsg(resp,
+                                'CS switch should never fail for non-I/O reason' +
+                                '... backend may now be in unstable state... ' +
+                                'failed on :: ' + err);
+                        else
+                            __postInternalErrorMsg(resp, err);
+                    }
+                );
+            } else {
+                let self = this;
+                let actions =
+                    [_fs.readFile('./users' + reqData['csmm'], 'utf8'),
+                        function (csmmData) {
+                            return __wHttpReq(
+                                'PUT',
+                                uri + '?wid=' + self.__aswid,
+                                {
+                                    'mm': reqData['asmm'],
+                                    'hitchhiker': {'csmm': csmmData, 'name': csmm}
+                                });
+                        }];
+
+                _do.chain(actions)(
+                    function () {
+                        __postMessage({'statusCode': 202, 'respIndex': resp});
+                    },
+                    function (err) {
+                        __postInternalErrorMsg(resp, err);
+                    }
+                );
+            }
+        },
+
+
+    /*  INTENT :
+            unload a metamodel (deletes all entities from that metamodel)
+        IN PRACTICE:
+            adjust uri and forward to asworker
+
+        1. parse + validate parameters
+        2. setup sync/async action chaining
+            a) ask asworker to unload corresponding AS mm
+        3. launch chain... on success, unload specified metamodel */
+    'DELETE *.metamodel':
+        function (resp, uri) {
+            let matches = uri.match(/(.*)\..*Icons(\.pattern){0,1}\.metamodel/);
+            if (!matches)
+                return __postBadReqErrorMsg(resp, 'bad uri for Icons mm :: ' + uri);
+
+            let asuri = matches[1] + (matches[2] || '') + '.metamodel';
+            let actions = [__wHttpReq('DELETE', asuri + '?wid=' + this.__aswid)];
+
+            _do.chain(actions)(
+                function () {
+                    __postMessage({'statusCode': 202, 'respIndex': resp});
+                },
+                function (err) {
+                    __postInternalErrorMsg(resp, err);
+                }
+            );
+        },
+
+
+    /*  INTENT :
+              load a model from disk
+                OR
+            clear current model (and metamodels)
+        IN PRACTICE:
+            adjust reqData and forward to asworker
+
+        1. parse + validate parameters
+        2. read specified model from disk
+                OR
+            fabricate empty model
+        3. setup sync/async action chaining
+            a) ask asworker to load associated AS model + pass CS model as
+                'hitchhiker'
+        4. launch chain... return success code or error */
+    'PUT /current.model':
+        function (resp, uri, reqData/*m[,insert]*/) {
+            if (reqData == undefined)
+                return __postBadReqErrorMsg(resp, 'missing model');
+
+            let self = this;
+            let mData = undefined;
+            let actions = [];
+            if (reqData['m'] == undefined)
+                // TODO: Is this a bug that actions isn't executed?
+                actions =
+                    [__successContinuable(),
+                        function () {
+                            mData = {
+                                "csm": {
+                                    "nodes": {},
+                                    "edges": [],
+                                    "metamodels": []
+                                },
+                                "asm": {
+                                    "nodes": {},
+                                    "edges": [],
+                                    "metamodels": []
+                                }
+                            };
+                            reqData['m'] = 'new';
+                            return __successContinuable(mData);
+                        }];
+            else {
+                try {
+                    _fs.accessSync('./users/' + reqData['m']);
+                } catch (e) {
+                    return __postBadReqErrorMsg(resp, 'cannot read ' + reqData['m']);
+                }
+                actions = [_fs.readFile('./users/' + reqData['m'], 'utf8'),
+                    function (_mData) {
+                        mData = eval('(' + _mData + ')');
+                        return __successContinuable(mData);
+                    }];
+                actions.push(
+                    function (m) {
+                        let asmData = _utils.jsons(m['asm']);
+                        let csmData = _utils.jsons(m['csm']);
+                        return __wHttpReq(
+                            'PUT',
+                            uri + '?wid=' + self.__aswid,
+                            {
+                                'm': asmData,
+                                'name': reqData['m'] + (new Date().getTime()),
+                                'insert': reqData['insert'],
+                                'hitchhiker': {'csm': csmData}
+                            });
+                    });
+                _do.chain(actions)(
+                    function () {
+                        __postMessage({'statusCode': 202, 'respIndex': resp});
+                    },
+                    function (err) {
+                        let MISSING_MM_ERROR = 'metamodel not loaded :: ';
+                        let matches = err.match('^500:' + MISSING_MM_ERROR + '(.*?)(\\.pattern){0,1}$');
+                        if (matches) {
+                            let asmm = matches[1];
+                            let pmm = (matches[2] != undefined);
+                            let csmm;
+                            mData['csm'].metamodels.some(
+                                function (mm) {
+                                    if ((pmm && mm.match(
+                                            '^' + asmm + '\\.[a-zA-Z0-9]*Icons\\.pattern$')) ||
+                                        (!pmm && mm.match(
+                                            '^' + asmm + '\\.[a-zA-Z0-9]*Icons$')))
+                                        csmm = mm;
+                                    return csmm;
+                                });
+                            __postInternalErrorMsg(resp, MISSING_MM_ERROR + csmm);
+                        } else
+                            __postInternalErrorMsg(resp, err);
+                    }
+                );
+            }
+        },
 
 
     /* INTENT :
@@ -1430,10 +1403,10 @@ logger.set_level(logger.LOG_LEVELS.INFO);
                     resp,
                     'bad uri for Icon/Link type :: ' + uri);
 
-            let asuri = matches[2] + (matches[3] || '') + '/' + matches[5] + '.type',
-                csmm = matches[1] + (matches[3] || ''),
-                cstype = matches[4],
-                types = _utils.jsonp(_mmmk.readMetamodels(csmm))['types'];
+            let asuri = matches[2] + (matches[3] || '') + '/' + matches[5] + '.type';
+            let csmm = matches[1] + (matches[3] || '');
+            let cstype = matches[4];
+            let types = _utils.jsonp(_mmmk.readMetamodels(csmm))['types'];
 
             if (!(cstype in types)) {
                 return __postBadReqErrorMsg(
@@ -1510,7 +1483,7 @@ logger.set_level(logger.LOG_LEVELS.INFO);
                                     [{'hitchhiker': hitchhiker}, reqParams]));
                         },
                         function (asreqData) {
-							return __wHttpReq(
+                            return __wHttpReq(
                                 'POST',
                                 asuri + '?wid=' + self.__aswid,
                                 asreqData);
@@ -1528,812 +1501,795 @@ logger.set_level(logger.LOG_LEVELS.INFO);
         },
 
 
-	/* return an AS instance, and optionally also the associated CS instance
+    /* return an AS instance, and optionally also the associated CS instance
 
-	1. setup sync/async action chaining
-		a) get AS instance uri for specified CS instance
-		b) ask asworker for AS instance
-	2. launch chain
-		... on success, 'return' instance possibly bundling CS instance
-		... on error, 'return' error */
-	'GET *.instance' :
-		function(resp,uri,reqData/*[full]*/)
-		{
-			var self	= this,
- 				 actions = 
-					[__successContinuable(),
-					function()
-					{
-						if( (asuri = self.__csuri_to_asuri(uri))['$err'] )
-							return __errorContinuable(asuri['$err']);
-						return __successContinuable(asuri);
-					},
-					function(asuri)	
-					{
-						return __wHttpReq('GET',asuri+'?wid='+self.__aswid);
-					}];
+    1. setup sync/async action chaining
+        a) get AS instance uri for specified CS instance
+        b) ask asworker for AS instance
+    2. launch chain
+        ... on success, 'return' instance possibly bundling CS instance
+        ... on error, 'return' error */
+    'GET *.instance':
+        function (resp, uri, reqData/*[full]*/) {
+            let self = this;
+            let actions =
+                [__successContinuable(),
+                    function () {
+                        let asuri = self.__csuri_to_asuri(uri);
+                        if (asuri['$err'])
+                            return __errorContinuable(asuri['$err']);
+                        return __successContinuable(asuri);
+                    },
+                    function (asuri) {
+                        return __wHttpReq('GET', asuri + '?wid=' + self.__aswid);
+                    }];
 
-			_do.chain(actions)(
-					function(respData) 
-					{
-						if( reqData && 'full' in reqData )
-							var data = {'cs':_mmmk.read(__uri_to_id(uri)),
-											'as':respData['data']};
-						else
-							var data = respData['data'];
+            _do.chain(actions)(
+                function (respData) {
+                    let data;
+                    if (reqData && 'full' in reqData)
+                        data = {
+                            'cs': _mmmk.read(__uri_to_id(uri)),
+                            'as': respData['data']
+                        };
+                    else
+                        data = respData['data'];
 
-						__postMessage(
-							{'statusCode':200, 
-	  						 'data':data,
-							 'sequence#':respData['sequence#'],					 
-							 'respIndex':resp});
-					},
-					function(err) 	{__postInternalErrorMsg(resp,err);}
-			);
-		},
-
-
-	/* INTENT :
-			update an AS instance's attributes
-		IN PRACTICE: 
-			adjust uri and forward to asworker
-
-		1. setup sync/async action chaining
-			a) determine associated AS instance uri
-			b) ask asworker to update it
-		2. launch chain... return success code or error */ 
-	'PUT *.instance' :
-		function(resp,uri,reqData)
-		{
-			var self	= this,
-				 actions = 
-					[__successContinuable(),
-					 function()
-					 {
-						 if( (asuri = self.__csuri_to_asuri(uri))['$err'] )
-							 return __errorContinuable(asuri['$err']);
-						 return __successContinuable(asuri);
-					 },
-					 function(asuri)	
-					 {
-						return __wHttpReq(
-							'PUT',
-							asuri+'?wid='+self.__aswid,
-							reqData);
-					 }];
-
-			_do.chain(actions)(
-					function(asnode) 
-					{
-						__postMessage(
-							{'statusCode':202, 					
-							 'respIndex':resp});
-					},
-					function(err) 	{__postInternalErrorMsg(resp,err);}
-			);
-		},
+                    __postMessage(
+                        {
+                            'statusCode': 200,
+                            'data': data,
+                            'sequence#': respData['sequence#'],
+                            'respIndex': resp
+                        });
+                },
+                function (err) {
+                    __postInternalErrorMsg(resp, err);
+                }
+            );
+        },
 
 
-	'POST *.instance.click' :
-		function(resp,uri,reqData)
-		{
-			/* TBA 
-				REST requests vs. code run on ASw
-				+ checkout bak/ for _mmmk.handleVisualObjectClick */
-		},
+    /* INTENT :
+            update an AS instance's attributes
+        IN PRACTICE:
+            adjust uri and forward to asworker
+
+        1. setup sync/async action chaining
+            a) determine associated AS instance uri
+            b) ask asworker to update it
+        2. launch chain... return success code or error */
+    'PUT *.instance':
+        function (resp, uri, reqData) {
+            let self = this;
+            let actions =
+                [__successContinuable(),
+                    function () {
+                        let asuri = self.__csuri_to_asuri(uri);
+                        if (asuri['$err'])
+                            return __errorContinuable(asuri['$err']);
+                        return __successContinuable(asuri);
+                    },
+                    function (asuri) {
+                        return __wHttpReq(
+                            'PUT',
+                            asuri + '?wid=' + self.__aswid,
+                            reqData);
+                    }];
+
+            _do.chain(actions)(
+                function (asnode) {
+                    __postMessage(
+                        {
+                            'statusCode': 202,
+                            'respIndex': resp
+                        });
+                },
+                function (err) {
+                    __postInternalErrorMsg(resp, err);
+                }
+            );
+        },
 
 
-	/* INTENT :
-			delete an instance 
-		IN PRACTICE: 
-			adjust uri and forward to asworker
-
-		1. setup sync/async action chaining
-			a) determine associated AS instance uri
-			b) ask asworker to delete it
-		2. launch chain... return success code 
-
-		NOTE:: this function does not return csworker errors to the client (i.e.,
-				 errors triggered by __csuri_to_asuri() failures)... the reason for
-				 this is that mmmk sometimes cascades deletes (e.g., deleting a 
-				 node alsos deletes any connected links) which often causes errors
-				 during 'mass' deletions, e.g., 
-				 	a) client requests
-				  			delete A
-							delete A->B
-				  			delete B
-					b) csworker handles delete A 		(deletes A and A->B)
-					c) csworker handles delete A->B 	(error, A->B already deleted)
-					... */
-	'DELETE *.instance' :
-		function(resp,uri)
-		{
-			var self  = this,
-				 asuri = this.__csuri_to_asuri(uri),
-				 actions = 
-					[__wHttpReq('DELETE',asuri+'?wid='+self.__aswid)];
-
-			if( asuri['$err'] )
-				__postMessage({'statusCode':200, 'respIndex':resp});
-			else {
-				_do.chain(actions)(
-					function() 
-					{
-						__postMessage({'statusCode':202, 'respIndex':resp});
-					},
-					function(err) 	
-					{
-						__postInternalErrorMsg(resp,err);
-					}
-				);
-			}
-		},
+    'POST *.instance.click':
+        function (resp, uri, reqData) {
+            /* TBA
+                REST requests vs. code run on ASw
+                + checkout bak/ for _mmmk.handleVisualObjectClick */
+        },
 
 
-	/* INTENT :
-			update a CS instance's attributes (position,...)
-		IN PRACTICE :
-			perform intent *or* possibly adjust uri and reqData and forward to
-		  	asworker
+    /* INTENT :
+            delete an instance
+        IN PRACTICE:
+            adjust uri and forward to asworker
 
-		1. retrieve the icon's parser
-	  	2. execute parser to determine AS impacts
-		3. if parsing produced an error, return it
-		3. if there are AS impacts, simulate an edit-via-dialog update by 
-			'forwarding' the request (with modified reqData) to 'PUT *.instance'
-			*and* bundle requested CS update (for later handling)
-		3. if there are no AS impacts, perform requested CS update and post 
-			changelog */
-	'PUT *.cs' :
-		function(resp,uri,reqData)
-		{			
-			var id 	= __uri_to_id(uri),
-				 icon = _utils.jsonp( _mmmk.read(id) ),
-				 updd = this.__runParser( 
-						 				icon['parser']['value'], 
-										reqData['changes'], 
-										icon );
+        1. setup sync/async action chaining
+            a) determine associated AS instance uri
+            b) ask asworker to delete it
+        2. launch chain... return success code
 
-			if( updd && updd['$err'] )
-				return __postInternalErrorMsg(resp,updd['$err']);
+        NOTE:: this function does not return csworker errors to the client (i.e.,
+                 errors triggered by __csuri_to_asuri() failures)... the reason for
+                 this is that mmmk sometimes cascades deletes (e.g., deleting a
+                 node alsos deletes any connected links) which often causes errors
+                 during 'mass' deletions, e.g.,
+                     a) client requests
+                              delete A
+                            delete A->B
+                              delete B
+                    b) csworker handles delete A 		(deletes A and A->B)
+                    c) csworker handles delete A->B 	(error, A->B already deleted)
+                    ... */
+    'DELETE *.instance':
+        function (resp, uri) {
+            let self = this;
+            let asuri = this.__csuri_to_asuri(uri);
+            let actions = [__wHttpReq('DELETE', asuri + '?wid=' + self.__aswid)];
 
-			if( updd )
-				this['PUT *.instance'](
-						resp,
-						uri,
-						{'changes':updd,
-						 'hitchhiker':{'cschanges':reqData['changes']}} );
-			else
-			{
-				var sn = __sequenceNumber();
-				this.__checkpointUserOperation(sn);			
-				__postMessage(
-						{'statusCode':200,
-  						 'changelog':
-						 	_mmmk.update(id,reqData['changes'])['changelog'].
-								concat('$segments' in reqData['changes'] ?
-										 	this.__positionLinkDecorators(id) :
-											[]),
-						 'sequence#':sn,
-						 'respIndex':resp});
-			}
-		},
+            if (asuri['$err'])
+                __postMessage({'statusCode': 200, 'respIndex': resp});
+            else {
+                _do.chain(actions)(
+                    function () {
+                        __postMessage({'statusCode': 202, 'respIndex': resp});
+                    },
+                    function (err) {
+                        __postInternalErrorMsg(resp, err);
+                    }
+                );
+            }
+        },
 
 
-	/* INTENT :
-			update a VisualObject's attributes
-		IN PRACTICE: 
-			perform intent *or* possibly adjust uri and reqData and forward to
-		  	asworker
+    /* INTENT :
+            update a CS instance's attributes (position,...)
+        IN PRACTICE :
+            perform intent *or* possibly adjust uri and reqData and forward to
+              asworker
 
-		1. parse + validate parameters
-		2. retrieve VisualObject and its parsing function
-		3. execute parsing function to determine AS impacts
-		4. if parsing produced an error, return it
-		4. if there are AS impacts, simulate an edit-via-dialog update by 
-			'forwarding' the request (with modified reqData) to 'PUT *.instance'
-			*and* bundle requested CS update (for later handling)
-		4. if there are no AS impacts, perform the requested VisualObject update
-	  		and post changelog */
-	'PUT *.vobject' :
-		function(resp,uri,reqData)
-		{
-			var matches = uri.match(/.*\/(.*)\.instance\/(.*)\.vobject/);
-			if( ! matches )
-				return __postBadReqErrorMsg(
-							resp,
-							'bad uri for VisualObject :: '+uri);
+        1. retrieve the icon's parser
+          2. execute parser to determine AS impacts
+        3. if parsing produced an error, return it
+        3. if there are AS impacts, simulate an edit-via-dialog update by
+            'forwarding' the request (with modified reqData) to 'PUT *.instance'
+            *and* bundle requested CS update (for later handling)
+        3. if there are no AS impacts, perform requested CS update and post
+            changelog */
+    'PUT *.cs':
+        function (resp, uri, reqData) {
+            let id = __uri_to_id(uri);
+            let icon = _utils.jsonp(_mmmk.read(id));
+            let updd = this.__runParser(
+                icon['parser']['value'],
+                reqData['changes'],
+                icon);
 
-			var id		 = matches[1],
-				 vid		 = matches[2],
-				 vobjAttr = '$contents/value/nodes/'+vid;
-			
-			if( (res = _mmmk.read(id,'$contents'))['$err'] )
-				return __postBadReqErrorMsg(resp,res['$err']);
+            if (updd && updd['$err'])
+                return __postInternalErrorMsg(resp, updd['$err']);
 
-			var __vo__ 	 = res['nodes'][vid],
-				 parsingf = __vo__['parser']['value'],
-	 			 updd 	 = this.__runParser( 
-						 					parsingf, 
-											reqData['changes'], 
-											__vo__ );
-
-			if( updd && updd['$err'] )
-				return __postInternalErrorMsg(resp,updd['$err']);
-
-			var _reqData = {};
-			for( var attr in reqData['changes'] )
-				_reqData[vobjAttr+'/'+attr] = reqData['changes'][attr];
-			
-			if( updd )
-				this['PUT *.instance'](
-						resp,
-						uri,
-						{'changes':updd,
-						 'hitchhiker':{'cschanges':_reqData}} );
-			else
-			{
-				var sn = __sequenceNumber();
-				this.__checkpointUserOperation(sn);		
-				__postMessage(
-						{'statusCode':200,
-  						 'changelog':_mmmk.update(id,_reqData)['changelog'],
-						 'sequence#':sn,
-						 'respIndex':resp});
-			}
-		},
+            if (updd)
+                this['PUT *.instance'](
+                    resp,
+                    uri,
+                    {
+                        'changes': updd,
+                        'hitchhiker': {'cschanges': reqData['changes']}
+                    });
+            else {
+                let sn = __sequenceNumber();
+                this.__checkpointUserOperation(sn);
+                __postMessage(
+                    {
+                        'statusCode': 200,
+                        'changelog':
+                            _mmmk.update(id, reqData['changes'])['changelog'].concat('$segments' in reqData['changes'] ?
+                                this.__positionLinkDecorators(id) :
+                                []),
+                        'sequence#': sn,
+                        'respIndex': resp
+                    });
+            }
+        },
 
 
-	/* INTENT :
-			A) generate a metamodel from the current AS model and write it to disk
-					OR
-			B) generate a CS metamodel (i.e., an icon definition metamodel) from 
-				the current AS and CS models and write it to disk
-					OR
-			C) generate pattern metamodels from AS and CS metamodels
+    /* INTENT :
+            update a VisualObject's attributes
+        IN PRACTICE:
+            perform intent *or* possibly adjust uri and reqData and forward to
+              asworker
 
-		IN PRACTICE: 
-			A) adjust uri and forward to asworker
-				OR
-			B) adjust uri and forward to asworker + bundle CS model
-				OR
-			C) do the deed
+        1. parse + validate parameters
+        2. retrieve VisualObject and its parsing function
+        3. execute parsing function to determine AS impacts
+        4. if parsing produced an error, return it
+        4. if there are AS impacts, simulate an edit-via-dialog update by
+            'forwarding' the request (with modified reqData) to 'PUT *.instance'
+            *and* bundle requested CS update (for later handling)
+        4. if there are no AS impacts, perform the requested VisualObject update
+              and post changelog */
+    'PUT *.vobject':
+        function (resp, uri, reqData) {
+            let matches = uri.match(/.*\/(.*)\.instance\/(.*)\.vobject/);
+            if (!matches)
+                return __postBadReqErrorMsg(
+                    resp,
+                    'bad uri for VisualObject :: ' + uri);
 
-		C) if the uri is a pattern metamodel uri,
-		1. setup sync/async action chaining
-			a) read AS metamodel + store contents
-			b) read contents of parent dir
-		2. launch chain... on error, return error... on success, 
-			a) setup another sync/async action chaining
-				i.   read all CS metamodels + store contents
-				ii.  call _mt.ramify() with AS and CS metamodel data
-				iii. write results to disk
-			b) launch chain... return success or error code 
-	 
-		B) if the uri is an icon definition metamodel uri,
-		1. setup sync/async action chaining
-			a) ask asworker to generate metamodel and write it to disk... asworker
-		  		request reqData includes the current CS model
-		2. launch chain... return success code or error 
+            let id = matches[1];
+            let vid = matches[2];
+            let vobjAttr = '$contents/value/nodes/' + vid;
 
-		A) otherwise,
-		1. setup sync/async action chaining
-			a) ask asworker to generate metamodel and write it to disk
-		2. launch chain... return success code or error */
-	'PUT *.metamodel' :
-		function(resp,uri)
-		{
-			if( (matches = uri.match(/\.pattern\.metamodel/)) )
-			{
-				let matches = uri.match(/\/GET(((.*\/).*).pattern.metamodel)/);
-				let RAMasmmPath = './users' + matches[1];
-				let asmmPath = './users' + matches[2] + '.metamodel';
-				let parentDir = './users' + matches[3];
-				let asmm = undefined;
-				let csmms = {};
-				let actions =
-					[_fs.readFile(asmmPath, 'utf8'),
-						function (data) {
-							asmm = data;
-							return _fs.readdir(parentDir);
-						}];
+            let res = _mmmk.read(id, '$contents');
+            if (res['$err'])
+                return __postBadReqErrorMsg(resp, res['$err']);
 
-				// only rewrite CS models matching the metamodel name
-				// obtains last token in path
-				let metamodel_name = matches[2].split("/").slice(-1)[0];
+            let __vo__ = res['nodes'][vid];
+            let parsingf = __vo__['parser']['value'];
+            let updd = this.__runParser(
+                parsingf,
+                reqData['changes'],
+                __vo__);
 
-				_do.chain(actions)(
-						function(files)
-						{
-							files =
-								  files.filter(
-	 								  function(f)
-									 	 {
-									 	 	let m = metamodel_name + "\..*Icons\.metamodel";
-									 	 	return f.match(m);
-									 	 });
+            if (updd && updd['$err'])
+                return __postInternalErrorMsg(resp, updd['$err']);
 
-							if (files.length === 0) {
-								throw 'could not match concrete syntax model to metamodel. model names must match';
-							}
+            let _reqData = {};
+            for (let attr in reqData['changes'])
+                _reqData[vobjAttr + '/' + attr] = reqData['changes'][attr];
 
-						  	var ramActions = [__successContinuable()];
-							files.forEach(
-								function(f)
-								{
-									ramActions.push(
-										function()
-										{
-											return _fs.readFile(parentDir+f,'utf8');
-										},
-										function(data)
-										{
-											csmms[f] = data;
-											return __successContinuable();
-  										});
-	 							});
-							ramActions.push(
-									function()
-									{
-										var res = _mt.ramify(_utils.jsonp(asmm),csmms);
-										asmm	= res['asmm'];
-										csmms = res['csmms'];
-										return _fs.writeFile(
-														RAMasmmPath,
-														_utils.jsons(asmm,null,'\t'));
-									});
-							files.forEach(
-								function(f)
-								{
-									ramActions.push(
-										function()
-										{
-											var RAMf = parentDir +
-														  f.match(/(.*)\.metamodel/)[1] +
-														  '.pattern.metamodel';
-                                            return _fs.writeFile(
-														RAMf,
-														_utils.jsons(csmms[f],null,'\t'));
-										});
-	 							});
+            if (updd)
+                this['PUT *.instance'](
+                    resp,
+                    uri,
+                    {
+                        'changes': updd,
+                        'hitchhiker': {'cschanges': _reqData}
+                    });
+            else {
+                let sn = __sequenceNumber();
+                this.__checkpointUserOperation(sn);
+                __postMessage(
+                    {
+                        'statusCode': 200,
+                        'changelog': _mmmk.update(id, _reqData)['changelog'],
+                        'sequence#': sn,
+                        'respIndex': resp
+                    });
+            }
+        },
 
-							_do.chain(ramActions)(
-								function()
-								{
-									__postMessage({'statusCode':200,'respIndex':resp});
-								},
-								function(err) 	{__postInternalErrorMsg(resp,err);}
-							);
-						},
-						function(err) 	{__postInternalErrorMsg(resp,err);}
-				);
-			}
-			else
-			{
-				var  matches   	 = uri.match(/\/GET(((.*\/).*)\..*Icons.metamodel)/),
-					 asmmPath  	 = (matches ? ('./users'+matches[2]+'.metamodel') : undefined),
-                     asmm       = undefined;
-                     aswid      = this.__aswid;
-                     actions    = [];
+
+    /* INTENT :
+            A) generate a metamodel from the current AS model and write it to disk
+                    OR
+            B) generate a CS metamodel (i.e., an icon definition metamodel) from
+                the current AS and CS models and write it to disk
+                    OR
+            C) generate pattern metamodels from AS and CS metamodels
+
+        IN PRACTICE:
+            A) adjust uri and forward to asworker
+                OR
+            B) adjust uri and forward to asworker + bundle CS model
+                OR
+            C) do the deed
+
+        C) if the uri is a pattern metamodel uri,
+        1. setup sync/async action chaining
+            a) read AS metamodel + store contents
+            b) read contents of parent dir
+        2. launch chain... on error, return error... on success,
+            a) setup another sync/async action chaining
+                i.   read all CS metamodels + store contents
+                ii.  call _mt.ramify() with AS and CS metamodel data
+                iii. write results to disk
+            b) launch chain... return success or error code
+
+        B) if the uri is an icon definition metamodel uri,
+        1. setup sync/async action chaining
+            a) ask asworker to generate metamodel and write it to disk... asworker
+                  request reqData includes the current CS model
+        2. launch chain... return success code or error
+
+        A) otherwise,
+        1. setup sync/async action chaining
+            a) ask asworker to generate metamodel and write it to disk
+        2. launch chain... return success code or error */
+    'PUT *.metamodel':
+        function (resp, uri) {
+            let matches = uri.match(/\.pattern\.metamodel/);
+            if (matches) {
+                let matches = uri.match(/\/GET(((.*\/).*).pattern.metamodel)/);
+                let RAMasmmPath = './users' + matches[1];
+                let asmmPath = './users' + matches[2] + '.metamodel';
+                let parentDir = './users' + matches[3];
+                let asmm = undefined;
+                let csmms = {};
+                let actions =
+                    [_fs.readFile(asmmPath, 'utf8'),
+                        function (data) {
+                            asmm = data;
+                            return _fs.readdir(parentDir);
+                        }];
+
+                // only rewrite CS models matching the metamodel name
+                // obtains last token in path
+                let metamodel_name = matches[2].split("/").slice(-1)[0];
+
+                _do.chain(actions)(
+                    function (files) {
+                        files =
+                            files.filter(
+                                function (f) {
+                                    let m = metamodel_name + "\..*Icons\.metamodel";
+                                    return f.match(m);
+                                });
+
+                        if (files.length === 0) {
+                            throw 'could not match concrete syntax model to metamodel. model names must match';
+                        }
+
+                        let ramActions = [__successContinuable()];
+                        files.forEach(
+                            function (f) {
+                                ramActions.push(
+                                    function () {
+                                        return _fs.readFile(parentDir + f, 'utf8');
+                                    },
+                                    function (data) {
+                                        csmms[f] = data;
+                                        return __successContinuable();
+                                    });
+                            });
+                        ramActions.push(
+                            function () {
+                                let res = _mt.ramify(_utils.jsonp(asmm), csmms);
+                                asmm = res['asmm'];
+                                csmms = res['csmms'];
+                                return _fs.writeFile(
+                                    RAMasmmPath,
+                                    _utils.jsons(asmm, null, '\t'));
+                            });
+                        files.forEach(
+                            function (f) {
+                                ramActions.push(
+                                    function () {
+                                        let RAMf = parentDir +
+                                            f.match(/(.*)\.metamodel/)[1] +
+                                            '.pattern.metamodel';
+                                        return _fs.writeFile(
+                                            RAMf,
+                                            _utils.jsons(csmms[f], null, '\t'));
+                                    });
+                            });
+
+                        _do.chain(ramActions)(
+                            function () {
+                                __postMessage({'statusCode': 200, 'respIndex': resp});
+                            },
+                            function (err) {
+                                __postInternalErrorMsg(resp, err);
+                            }
+                        );
+                    },
+                    function (err) {
+                        __postInternalErrorMsg(resp, err);
+                    }
+                );
+            } else {
+                let matches = uri.match(/\/GET(((.*\/).*)\..*Icons.metamodel)/);
+                let asmmPath = (matches ? ('./users' + matches[2] + '.metamodel') : undefined);
+                let asmm = undefined;
+                let aswid = this.__aswid;
+                let actions;
                 if (asmmPath) {
-					actions = [
-						_fs.readFile(asmmPath,'utf8'),
-						function(data) {
-							asmm = _utils.jsonp(data);
-							return __successContinuable();
-						},
-						function(result) {
-							return __wHttpReq('PUT',
-								uri+'?wid='+aswid,
-								({'csm':_mmmk.read(), 'asmm': asmm}))
-                            }]
+                    actions = [
+                        _fs.readFile(asmmPath, 'utf8'),
+                        function (data) {
+                            asmm = _utils.jsonp(data);
+                            return __successContinuable();
+                        },
+                        function (result) {
+                            return __wHttpReq('PUT',
+                                uri + '?wid=' + aswid,
+                                ({'csm': _mmmk.read(), 'asmm': asmm}))
+                        }]
                 } else {
-					actions = [__wHttpReq('PUT',
-						uri+'?wid='+aswid,
+                    actions = [__wHttpReq('PUT',
+                        uri + '?wid=' + aswid,
                         undefined)];
                 }
-            	_do.chain(actions)(
-                    function() { __postMessage({'statusCode':200,'respIndex':resp}); },
-                    function(err) {__postInternalErrorMsg(resp,err);}
-                 );
-			}
-		},
+                _do.chain(actions)(
+                    function () {
+                        __postMessage({'statusCode': 200, 'respIndex': resp});
+                    },
+                    function (err) {
+                        __postInternalErrorMsg(resp, err);
+                    }
+                );
+            }
+        },
 
 
-	/* write a bundle containing this CS model and its associated AS model to 
-		disk
+    /* write a bundle containing this CS model and its associated AS model to
+        disk
 
-		1. setup sync/async action chaining
-			a) ask asworker for current model (AS)			
-		2. launch chain... on error, return error... on success, compare sequence#
-			of returned AS model with next expected sequence# from asworker
-				a) if AS model is too old, restart
-			  	b) if AS model is too recent, wait 200 ms and restart
-				c) otherwise, 
-					i.   extract path info
-					ii.  return error on invalid path
-					iii. ask _mmmk for current model (CS)
-					iv.  setup another sync/async action chaining
-							 a) write bundled AS and CS models to disk
-					v.   launch chain... return success or error code */
-	'PUT *.model' :
-		function(resp,uri)
-		{
-			var self		= this,
-				 actions = [__wHttpReq('GET','/current.model?wid='+this.__aswid)];
+        1. setup sync/async action chaining
+            a) ask asworker for current model (AS)
+        2. launch chain... on error, return error... on success, compare sequence#
+            of returned AS model with next expected sequence# from asworker
+                a) if AS model is too old, restart
+                  b) if AS model is too recent, wait 200 ms and restart
+                c) otherwise,
+                    i.   extract path info
+                    ii.  return error on invalid path
+                    iii. ask _mmmk for current model (CS)
+                    iv.  setup another sync/async action chaining
+                             a) write bundled AS and CS models to disk
+                    v.   launch chain... return success or error code */
+    'PUT *.model':
+        function (resp, uri) {
+            let self = this;
+            let actions = [__wHttpReq('GET', '/current.model?wid=' + this.__aswid)];
 
-			_do.chain(actions)(
-					function(asdata)
-					{
-						var sn = asdata['sequence#'];
-						if( self.__nextASWSequenceNumber - 1 > sn )
-							self['PUT *.model'](resp,uri);
-						else if( self.__nextASWSequenceNumber - 1 < sn )
-							setTimeout(self['PUT *.model'], 200, resp, uri);
-						else
-						{
-							if( (res = _mmmk.read())['$err'] )
-								__postInternalErrorMsg(resp,res['$err']);
-							else
-							{
-								var path  = './users'+uri.substring('/GET'.length),
-									 dir	 = _path.dirname(path);
+            _do.chain(actions)(
+                function (asdata) {
+                    let sn = asdata['sequence#'];
+                    if (self.__nextASWSequenceNumber - 1 > sn)
+                        self['PUT *.model'](resp, uri);
+                    else if (self.__nextASWSequenceNumber - 1 < sn)
+                        setTimeout(self['PUT *.model'], 200, resp, uri);
+                    else {
+                        let res = _mmmk.read();
+                        if (res['$err'])
+                            __postInternalErrorMsg(resp, res['$err']);
+                        else {
+                            let path = './users' + uri.substring('/GET'.length);
+                            let dir = _path.dirname(path);
 
-								if( dir.match(/"/) )
-									throw 'illegal filename... these characters are not'+
-									  		' allowed in filenames :: "';
+                            if (dir.match(/"/))
+                                throw 'illegal filename... these characters are not' +
+                                ' allowed in filenames :: "';
 
-								var mData = {
-										'csm':_utils.jsonp(res),
-										'asm':_utils.jsonp(asdata['data'])},
-									 writeActions = 
-										[_fspp.mkdirs(dir),
-									 	 function()
-										 {
-											 return _fs.writeFile(
-															path,
-															_utils.jsons(mData,null,'\t'));
-										 }];
-								_do.chain(writeActions)(
-									function()
-									{
-										__postMessage(
-											{'statusCode':200,
-	  										 'respIndex':resp});
-									},
-									function(writeErr)	
-									{
-										__postInternalErrorMsg(resp,writeErr);
-									}
-								);
-							}
-						}
-					},
-					function(err) 	{__postInternalErrorMsg(resp,err);}
-			);
-		},
-	
-
-	/* INTENT :
-			validate the associated AS model 
-		IN PRACTICE: 
-			adjust uri and forward to asworker
-
-	1. setup sync/async action chaining
-		a) ask asworker to validate its model
-	2. launch chain... return success code or error */
-	'GET /validatem' :
-		function(resp,uri)
-		{
-			var actions = [__wHttpReq('GET',uri+'?wid='+this.__aswid)];
-
-			_do.chain(actions)(
-					function() 
-					{
-						__postMessage({'statusCode':200, 'respIndex':resp});
-					},
-					function(err) 	{__postInternalErrorMsg(resp,err);}
-			);
-		},
+                            let mData = {
+                                'csm': _utils.jsonp(res),
+                                'asm': _utils.jsonp(asdata['data'])
+                            };
+                            let writeActions =
+                                [_fspp.mkdirs(dir),
+                                    function () {
+                                        return _fs.writeFile(
+                                            path,
+                                            _utils.jsons(mData, null, '\t'));
+                                    }];
+                            _do.chain(writeActions)(
+                                function () {
+                                    __postMessage(
+                                        {
+                                            'statusCode': 200,
+                                            'respIndex': resp
+                                        });
+                                },
+                                function (writeErr) {
+                                    __postInternalErrorMsg(resp, writeErr);
+                                }
+                            );
+                        }
+                    }
+                },
+                function (err) {
+                    __postInternalErrorMsg(resp, err);
+                }
+            );
+        },
 
 
-	/* INTENT :
-			undo/redo the effects of a client's last not yet undone/redone action
-		IN PRACTICE: 
-			adjust uri and forward asworker undo/redos to asworker, and handle 
-			csworker undo/redos locally
+    /* INTENT :
+            validate the associated AS model
+        IN PRACTICE:
+            adjust uri and forward to asworker
 
-	1. if next __handledSeqNums is a non-csworker sequence#,
-		a) if it's a batchEdit marker:
-			i.   adjust __handledSeqNums['i'] to account for multiple undos/redos
-			ii.  populate reqData['redo/undoUntil'] with batchEdit marker s.t. 
-				  asworker knows to undo/redo everything til specified marker
-			iii. populate hitchhiker['redo/undo'] with batchEdit marker s.t. when 
-				  asworker undo/redo changelog comes around, csworkers know until 
-				  where they should undo/redo
-			iv. forward request to asworker and return success code or error
-		a) if it's an asworker marker:
-			i.   populate hitchhiker['redo/undo'] with asworker marker s.t. when
-				  asworker undo/redo changelog comes around, csworkers know until 
-				  where they should undo/redo
-			ii.  forward request to asworker and return success code or error */
-	'POST /undo' :
-		function(resp,uri,reqData/*[undoUntil]*/)
-		{
-			if( this.__handledSeqNums['i'] == undefined )
-				this.__handledSeqNums['i'] = this.__handledSeqNums['#s'].length-1;
-			if( this.__handledSeqNums['#s'][this.__handledSeqNums['i']] )
-				this.__undoredo(
-							resp,
-							uri,
-							(reqData != undefined && 'undoUntil' in reqData ?
-							 	reqData['undoUntil'] :
-								this.__handledSeqNums['#s'][this.__handledSeqNums['i']--]),
-							'undo');
-			else
-				__postMessage({'statusCode':200, 'respIndex':resp});
+    1. setup sync/async action chaining
+        a) ask asworker to validate its model
+    2. launch chain... return success code or error */
+    'GET /validatem':
+        function (resp, uri) {
+            let actions = [__wHttpReq('GET', uri + '?wid=' + this.__aswid)];
 
-		},
-	'POST /redo' :
-		function(resp,uri)
-		{
-			if( this.__handledSeqNums['i'] == undefined )
-				this.__handledSeqNums['i'] = this.__handledSeqNums['#s'].length-1;
-			if( this.__handledSeqNums['#s'][this.__handledSeqNums['i']+1] )
-				this.__undoredo(
-						resp,
-						uri,
-						this.__handledSeqNums['#s'][++this.__handledSeqNums['i']],
-						'redo');
-			else
-				__postMessage({'statusCode':200, 'respIndex':resp});
-			
-		},
-	'__undoredo' :
-		function(resp,uri,sn,func)
-		{
-			if( ! sn.match(get__wtype()) )
-			{
-				var hitchhiker = {},
-					 reqData		= {'hitchhiker':hitchhiker},
-					 actions 	= [__wHttpReq(
-											 'POST',
-			 								 uri+'?wid='+this.__aswid,
-											 reqData) ];
-
-				if( (matches = sn.match(/^bchkpt@([0-9]+)/)) )
-				{
-					if( func == 'undo' )
-					{
-						for( ;
-						  ! this.__handledSeqNums['#s'][this.__handledSeqNums['i']].
-						  		match('^bchkpt@'+matches[1]);
-					     this.__handledSeqNums['i']-- )	
-							;
-						this.__handledSeqNums['i']--;
-						reqData[func+'Until'] = hitchhiker[func] = 
-							__batchCheckpoint(matches[1],true);
-					}
-					else
-					{
-						this.__handledSeqNums['i']++;
-						for( ;
-						  ! this.__handledSeqNums['#s'][this.__handledSeqNums['i']].
-						  		match('^bchkpt@'+matches[1]);
-					     this.__handledSeqNums['i']++ ) 
-							;
-						reqData[func+'Until'] = hitchhiker[func] =
-						  	__batchCheckpoint(matches[1]);
-					}
-				}
-				else
-					hitchhiker[func] = sn;					
-				_do.chain( actions )(
-					function() 
-					{
-						__postMessage({'statusCode':202, 'respIndex':resp});
-					},
-					function(err) 	{__postInternalErrorMsg(resp,err);}
-				);
-			}
-			else
-				__postMessage(
-					{'statusCode':200,
-					 'changelog':_mmmk[func](sn)['changelog'],
-					 'sequence#':__sequenceNumber(),
-					 'respIndex':resp});
-		},
+            _do.chain(actions)(
+                function () {
+                    __postMessage({'statusCode': 200, 'respIndex': resp});
+                },
+                function (err) {
+                    __postInternalErrorMsg(resp, err);
+                }
+            );
+        },
 
 
-	/* INTENT :
-			place an easily identifiable user-checkpoint in the journal
-		IN PRACTICE: 
-			adjust uri and forward to asworker
+    /* INTENT :
+            undo/redo the effects of a client's last not yet undone/redone action
+        IN PRACTICE:
+            adjust uri and forward asworker undo/redos to asworker, and handle
+            csworker undo/redos locally
 
-	1. setup sync/async action chaining
-		a) forward request to asworker
-	2. launch chain... return success code or error */
-	'POST /batchCheckpoint' :
-		function(resp,uri,reqData)
-		{
-			var actions = [
-				__wHttpReq('POST',uri+'?wid='+this.__aswid,reqData)];
-			_do.chain(actions)(
-					function() 
-					{
-						__postMessage({'statusCode':202, 'respIndex':resp});
-					},
-					function(err) 	{__postInternalErrorMsg(resp,err);}
-			);
-		},
+    1. if next __handledSeqNums is a non-csworker sequence#,
+        a) if it's a batchEdit marker:
+            i.   adjust __handledSeqNums['i'] to account for multiple undos/redos
+            ii.  populate reqData['redo/undoUntil'] with batchEdit marker s.t.
+                  asworker knows to undo/redo everything til specified marker
+            iii. populate hitchhiker['redo/undo'] with batchEdit marker s.t. when
+                  asworker undo/redo changelog comes around, csworkers know until
+                  where they should undo/redo
+            iv. forward request to asworker and return success code or error
+        a) if it's an asworker marker:
+            i.   populate hitchhiker['redo/undo'] with asworker marker s.t. when
+                  asworker undo/redo changelog comes around, csworkers know until
+                  where they should undo/redo
+            ii.  forward request to asworker and return success code or error */
+    'POST /undo':
+        function (resp, uri, reqData/*[undoUntil]*/) {
+            if (this.__handledSeqNums['i'] == undefined)
+                this.__handledSeqNums['i'] = this.__handledSeqNums['#s'].length - 1;
+            if (this.__handledSeqNums['#s'][this.__handledSeqNums['i']])
+                this.__undoredo(
+                    resp,
+                    uri,
+                    (reqData != undefined && 'undoUntil' in reqData ?
+                        reqData['undoUntil'] :
+                        this.__handledSeqNums['#s'][this.__handledSeqNums['i']--]),
+                    'undo');
+            else
+                __postMessage({'statusCode': 200, 'respIndex': resp});
 
+        },
+    'POST /redo':
+        function (resp, uri) {
+            if (this.__handledSeqNums['i'] == undefined)
+                this.__handledSeqNums['i'] = this.__handledSeqNums['#s'].length - 1;
+            if (this.__handledSeqNums['#s'][this.__handledSeqNums['i'] + 1])
+                this.__undoredo(
+                    resp,
+                    uri,
+                    this.__handledSeqNums['#s'][++this.__handledSeqNums['i']],
+                    'redo');
+            else
+                __postMessage({'statusCode': 200, 'respIndex': resp});
 
+        },
+    '__undoredo':
+        function (resp, uri, sn, func) {
+            if (!sn.match(get__wtype())) {
+                let hitchhiker = {};
+                let reqData = {'hitchhiker': hitchhiker};
+                let actions = [__wHttpReq(
+                    'POST',
+                    uri + '?wid=' + this.__aswid,
+                    reqData)];
 
-	/********************************** UTILS **********************************/
-	/* wrapper around reads to '__asid2csid'...  needed because loading a model 
-		(as opposed to creating it from scratch) doesn't populate this data 
-		structure... this wrapper enables its lazy and transparent population as
-	  	read queries are made */
-	'__asid_to_csid' :
-		function(asid)
-		{
-			if( this.__asid2csid[asid] != undefined )
-				return this.__asid2csid[asid];
-
-			var csm = _utils.jsonp(_mmmk.read());
-			for( var csid in csm.nodes )
-				if( __uri_to_id(_mmmk.read(csid,'$asuri')) == asid )
-					return (this.__asid2csid[asid] = csid);
-		},
-
-
-	/* return a fullcstype from a fullastype */
-	'__astype_to_cstype' :
-		function(fullastype,isLink)
-		{
-			var matches = fullastype.match(/(.*)\/(.*)/),
-				 asmm 	= matches[1],
-				 astype	= matches[2];
-			return this.__asmm2csmm[asmm]+'/'+astype+(isLink ? 'Link' : 'Icon');
-		},
-
-
-	/* return the CS instance uri associated to the AS instance described by the
-		given uri */
-	'__asuri_to_csuri' :
-		function(uri)
-		{
-			if( (asid = __uri_to_id(uri))['$err'] )
-				return asid;
-			return __id_to_uri(this.__asid_to_csid(asid));
-		},
-
-
-	/* add a checkpointing marker in mmmk and log the said marker as a 
-		non-undo/redo operation (remove any undone operations from log first) */
-	'__checkpointUserOperation' :
-		function(sn)
-		{
-			_mmmk.setUserCheckpoint(sn);
-			if( this.__handledSeqNums['i'] != undefined )
-			{
-				this.__handledSeqNums['#s'].splice( this.__handledSeqNums['i']+1 );
-				this.__handledSeqNums['i'] = undefined;
-			}
-			this.__handledSeqNums['#s'].push(sn);			
-		},
-
-
-	/* produce a bundle of internal state variables sufficient to fully clone 
-		this instance
-			OR
-		use a provided bundle to overwrite this instance's internal state */
-	'__clone' :
-		function(clone)
-		{
-			if( clone )
-			{
-				this.__asmm2csmm 					= clone.__asmm2csmm;
-				this.__asid2csid 					= clone.__asid2csid;
-				this.__aswid						= clone.__aswid;
-				this.__handledSeqNums 			= clone.__handledSeqNums;
-				this.__nextASWSequenceNumber  = clone.__nextASWSequenceNumber;
-				this.__pendingChangelogs 		= clone.__pendingChangelogs;
-				this.__hitchhikerJournal		= clone.__hitchhikerJournal;
-			}
-			else
-				return _utils.clone(
-							{'__asmm2csmm':					this.__asmm2csmm,
-							 '__asid2csid':					this.__asid2csid,
-							 '__aswid':							this.__aswid,
-							 '__handledSeqNums':				this.__handledSeqNums,
-						 	 '__nextASWSequenceNumber':	this.__nextASWSequenceNumber,
-						 	 '__pendingChangelogs':			this.__pendingChangelogs,
-				 			 '__hitchhikerJournal':			this.__hitchhikerJournal});
-		},
+                let matches = sn.match(/^bchkpt@([0-9]+)/);
+                if (matches) {
+                    if (func == 'undo') {
+                        for (;
+                            !this.__handledSeqNums['#s'][this.__handledSeqNums['i']].match('^bchkpt@' + matches[1]);
+                            this.__handledSeqNums['i']--)
+                            ;
+                        this.__handledSeqNums['i']--;
+                        reqData[func + 'Until'] = hitchhiker[func] =
+                            __batchCheckpoint(matches[1], true);
+                    } else {
+                        this.__handledSeqNums['i']++;
+                        for (;
+                            !this.__handledSeqNums['#s'][this.__handledSeqNums['i']].match('^bchkpt@' + matches[1]);
+                            this.__handledSeqNums['i']++)
+                            ;
+                        reqData[func + 'Until'] = hitchhiker[func] =
+                            __batchCheckpoint(matches[1]);
+                    }
+                } else
+                    hitchhiker[func] = sn;
+                _do.chain(actions)(
+                    function () {
+                        __postMessage({'statusCode': 202, 'respIndex': resp});
+                    },
+                    function (err) {
+                        __postInternalErrorMsg(resp, err);
+                    }
+                );
+            } else
+                __postMessage(
+                    {
+                        'statusCode': 200,
+                        'changelog': _mmmk[func](sn)['changelog'],
+                        'sequence#': __sequenceNumber(),
+                        'respIndex': resp
+                    });
+        },
 
 
-	/* return the AS instance uri associated to the CS instance described by the
-		given uri */
-	'__csuri_to_asuri' :
-		function(uri)
-		{
-			if( (csid = __uri_to_id(uri))['$err'] )
-				return csid;
-			else if( (asuri = _mmmk.read(csid,'$asuri'))['$err'] )
-				return asuri;
-			return asuri;
-		},
+    /* INTENT :
+            place an easily identifiable user-checkpoint in the journal
+        IN PRACTICE:
+            adjust uri and forward to asworker
+
+    1. setup sync/async action chaining
+        a) forward request to asworker
+    2. launch chain... return success code or error */
+    'POST /batchCheckpoint':
+        function (resp, uri, reqData) {
+            let actions = [
+                __wHttpReq('POST', uri + '?wid=' + this.__aswid, reqData)];
+            _do.chain(actions)(
+                function () {
+                    __postMessage({'statusCode': 202, 'respIndex': resp});
+                },
+                function (err) {
+                    __postInternalErrorMsg(resp, err);
+                }
+            );
+        },
 
 
-	/* compute 'default' segments between the given icons (specified via uri) */
-	'__defaultSegments' :
-		function(src,dest)
-		{
-			var pos1 	= _mmmk.read(__uri_to_id(src),'position'),
-				 pos2 	= _mmmk.read(__uri_to_id(dest),'position'),
-				 middle	= [pos2[0]-(pos2[0]-pos1[0])/2.0,
-								pos2[1]-(pos2[1]-pos1[1])/2.0];
-			return ['M'+pos1+'L'+middle, 'M'+middle+'L'+pos2];
-		},
+    /********************************** UTILS **********************************/
+    /* wrapper around reads to '__asid2csid'...  needed because loading a model
+        (as opposed to creating it from scratch) doesn't populate this data
+        structure... this wrapper enables its lazy and transparent population as
+          read queries are made */
+    '__asid_to_csid':
+        function (asid) {
+            if (this.__asid2csid[asid] != undefined)
+                return this.__asid2csid[asid];
+
+            let csm = _utils.jsonp(_mmmk.read());
+            for (let csid in csm.nodes)
+                if (__uri_to_id(_mmmk.read(csid, '$asuri')) == asid)
+                    return (this.__asid2csid[asid] = csid);
+        },
 
 
-	/* compute the x,y center of the icons given by the specified AS uris */
-	'__nodesCenter' :
-		function(asuris)
-		{
-			var sumx = 0,
-				 sumy = 0,
-				 self = this;
-			asuris.forEach(
-					function(asuri)
-					{
-						var asid = __uri_to_id(asuri),
-							 csid = self.__asid_to_csid(asid),
-							 pos 	= _mmmk.read(csid,'position');
-						sumx += parseFloat(pos[0]);
-						sumy += parseFloat(pos[1]);
-					});
-			return [sumx/asuris.length, sumy/asuris.length];
-		},
+    /* return a fullcstype from a fullastype */
+    '__astype_to_cstype':
+        function (fullastype, isLink) {
+            let matches = fullastype.match(/(.*)\/(.*)/);
+            let asmm = matches[1];
+            let astype = matches[2];
+            return this.__asmm2csmm[asmm] + '/' + astype + (isLink ? 'Link' : 'Icon');
+        },
 
 
-	/* run given code within given contexts
-
-		1. setup a very stripped down version of _mmmk.__runDesignerCode() with
-		  	getAttr() and safe_eval() (see _mmmk.__runDesignerCode() for more 
-			elaborate comments) 
-		2. safely evaluate code and return result
-				
-		NOTE: getAttr() first checks the 'local' context and then the 'global'
-				context to find requested attributes... this enables such behaviours
-				as accessing 'new'  attribute values as opposed to those stored in 
-				_mmmk */
-	'__runParser' :
-		function(parser,local,global)
-		{
-			function getAttr(_attr)
-			{
-				if( _attr in local )
-					return local[_attr];
-				else if( !(_attr in global) || _attr.charAt(0) == '$')
-					throw 'invalid getAttr() attribute :: '+_attr;
-				return _utils.clone(global[_attr]['value']);
-			}
-			function safe_eval(code)
-			{
-				try			{return eval(code);}
-				catch(err)	{return {'$err':err};}
-			}	
-
-			return safe_eval(parser);
-		},
+    /* return the CS instance uri associated to the AS instance described by the
+        given uri */
+    '__asuri_to_csuri':
+        function (uri) {
+            let asid = __uri_to_id(uri)
+            if (asid['$err'])
+                return asid;
+            return __id_to_uri(this.__asid_to_csid(asid));
+        },
 
 
-	/* returns the numeric part of sequence# of the form 'src#number' */
-	'__sn2int' :
-		function(sn)
-		{
-			return parseInt(sn.match(/.*#(\d*)/)[1]);
-		}
+    /* add a checkpointing marker in mmmk and log the said marker as a
+        non-undo/redo operation (remove any undone operations from log first) */
+    '__checkpointUserOperation':
+        function (sn) {
+            _mmmk.setUserCheckpoint(sn);
+            if (this.__handledSeqNums['i'] != undefined) {
+                this.__handledSeqNums['#s'].splice(this.__handledSeqNums['i'] + 1);
+                this.__handledSeqNums['i'] = undefined;
+            }
+            this.__handledSeqNums['#s'].push(sn);
+        },
+
+
+    /* produce a bundle of internal state variables sufficient to fully clone
+        this instance
+            OR
+        use a provided bundle to overwrite this instance's internal state */
+    '__clone':
+        function (clone) {
+            if (clone) {
+                this.__asmm2csmm = clone.__asmm2csmm;
+                this.__asid2csid = clone.__asid2csid;
+                this.__aswid = clone.__aswid;
+                this.__handledSeqNums = clone.__handledSeqNums;
+                this.__nextASWSequenceNumber = clone.__nextASWSequenceNumber;
+                this.__pendingChangelogs = clone.__pendingChangelogs;
+                this.__hitchhikerJournal = clone.__hitchhikerJournal;
+            } else
+                return _utils.clone(
+                    {
+                        '__asmm2csmm': this.__asmm2csmm,
+                        '__asid2csid': this.__asid2csid,
+                        '__aswid': this.__aswid,
+                        '__handledSeqNums': this.__handledSeqNums,
+                        '__nextASWSequenceNumber': this.__nextASWSequenceNumber,
+                        '__pendingChangelogs': this.__pendingChangelogs,
+                        '__hitchhikerJournal': this.__hitchhikerJournal
+                    });
+        },
+
+
+    /* return the AS instance uri associated to the CS instance described by the
+        given uri */
+    '__csuri_to_asuri':
+        function (uri) {
+            let csid = __uri_to_id(uri);
+            if (csid['$err'])
+                return csid;
+            let asuri = _mmmk.read(csid, '$asuri');
+            if (asuri['$err'])
+                return asuri;
+            return asuri;
+        },
+
+
+    /* compute 'default' segments between the given icons (specified via uri) */
+    '__defaultSegments':
+        function (src, dest) {
+            let pos1 = _mmmk.read(__uri_to_id(src), 'position');
+            let pos2 = _mmmk.read(__uri_to_id(dest), 'position');
+            let middle = [pos2[0] - (pos2[0] - pos1[0]) / 2.0,
+                pos2[1] - (pos2[1] - pos1[1]) / 2.0];
+            return ['M' + pos1 + 'L' + middle, 'M' + middle + 'L' + pos2];
+        },
+
+
+    /* compute the x,y center of the icons given by the specified AS uris */
+    '__nodesCenter':
+        function (asuris) {
+            let sumx = 0;
+            let sumy = 0;
+            let self = this;
+            asuris.forEach(
+                function (asuri) {
+                    let asid = __uri_to_id(asuri);
+                    let csid = self.__asid_to_csid(asid);
+                    let pos = _mmmk.read(csid, 'position');
+                    sumx += parseFloat(pos[0]);
+                    sumy += parseFloat(pos[1]);
+                });
+            return [sumx / asuris.length, sumy / asuris.length];
+        },
+
+
+    /* run given code within given contexts
+
+        1. setup a very stripped down version of _mmmk.__runDesignerCode() with
+              getAttr() and safe_eval() (see _mmmk.__runDesignerCode() for more
+            elaborate comments)
+        2. safely evaluate code and return result
+
+        NOTE: getAttr() first checks the 'local' context and then the 'global'
+                context to find requested attributes... this enables such behaviours
+                as accessing 'new'  attribute values as opposed to those stored in
+                _mmmk */
+    '__runParser':
+        function (parser, local, global) {
+            function getAttr(_attr) {
+                if (_attr in local)
+                    return local[_attr];
+                else if (!(_attr in global) || _attr.charAt(0) == '$')
+                    throw 'invalid getAttr() attribute :: ' + _attr;
+                return _utils.clone(global[_attr]['value']);
+            }
+
+            function safe_eval(code) {
+                try {
+                    return eval(code);
+                } catch (err) {
+                    return {'$err': err};
+                }
+            }
+
+            return safe_eval(parser);
+        },
+
+
+    /* returns the numeric part of sequence# of the form 'src#number' */
+    '__sn2int':
+        function (sn) {
+            return parseInt(sn.match(/.*#(\d*)/)[1]);
+        }
 };


### PR DESCRIPTION
This change is large but is almost entirely minor formatting and maintainability fixes.

For example, using `let` instead of `var`. Also, pulling assignments out of conditionals.

This has two primary benefits. First, the code is easier to read and understand, though it is a bit longer. Second, my IDE (Webstorm) no longer complains about all these minor issues. This makes it easier to see regressions.

No semantics should be changed by these commits. However, it is possible because `var` has a wider scope than `let`.