### PR TITLE
Nightwatch

### DIFF
--- a/.github/workflows/atompm_test.yml
+++ b/.github/workflows/atompm_test.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         pip3 install six wheel websocket-client python-socketio[client] python-socketio
         pip3 install --user python-igraph
-        
+    
     - name: run tests
       run: |
 # if we are running xvfb there is no need to run headless; remaining parameters passed to nightwatch configuration

--- a/.github/workflows/atompm_test.yml
+++ b/.github/workflows/atompm_test.yml
@@ -54,8 +54,12 @@ jobs:
         pip3 install six wheel websocket-client python-socketio[client] python-socketio
         pip3 install --user python-igraph
     
+#    - name: run tests
+#      run: |
+#        chromium --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+#        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh
+
     - name: run tests
       run: |
-        chromium --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
         xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh
         

--- a/.github/workflows/atompm_test.yml
+++ b/.github/workflows/atompm_test.yml
@@ -56,6 +56,7 @@ jobs:
         
     - name: run tests
       run: |
-        chromium --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+# if we are running xvfb there is no need to run headless; remaining parameters passed to nightwatch configuration
+#        chromium --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
         xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh
         

--- a/.github/workflows/atompm_test.yml
+++ b/.github/workflows/atompm_test.yml
@@ -63,45 +63,45 @@ jobs:
 
     - name: run test 01_startup_test
       run: |
-        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/01_startup_test.js
+        ./run_tests.sh headless ./tests/01_startup_test.js
 
     - name: run test 02_login_test
       run: |
-        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/02_login_test.js
+        ./run_tests.sh headless  ./tests/02_login_test.js
 
     - name: run test 03_model_test
       run: |
-        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/03_model_test.js
+        ./run_tests.sh headless  ./tests/03_model_test.js
 
     - name: run test 04_compile_test
       run: |
-        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/04_compile_test.js
+        ./run_tests.sh headless  ./tests/04_compile_test.js
 
     - name: run test 05_toolbar_test
       run: |
-        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/05_toolbar_test.js
+        ./run_tests.sh headless  ./tests/05_toolbar_test.js
 
     - name: run test 06_creating_dsl
       run: |
-        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/06_creating_dsl.js
+        ./run_tests.sh headless  ./tests/06_creating_dsl.js
 
     - name: run test 07_transformation_test
       run: |
-        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/07_transformation_test.js
+        ./run_tests.sh headless  ./tests/07_transformation_test.js
 
     - name: run test 08_pacman_transformation_test
       run: |
-        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/08_pacman_transformation_test.js
+        ./run_tests.sh headless  ./tests/08_pacman_transformation_test.js
 
     - name: run test 09_missing_files
       run: |
-        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/09_missing_files.js
+        ./run_tests.sh headless  ./tests/09_missing_files.js
 
     - name: run test 10_undo_test
       run: |
-        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/10_undo_test.js
+        ./run_tests.sh headless  ./tests/10_undo_test.js
 
     - name: run test 99_ecore_toolbar_test
       run: |
-        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/99_ecore_toolbar_test.js
+        ./run_tests.sh headless  ./tests/99_ecore_toolbar_test.js
 

--- a/.github/workflows/atompm_test.yml
+++ b/.github/workflows/atompm_test.yml
@@ -59,7 +59,49 @@ jobs:
 #        chromium --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 #        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh
 
-    - name: run tests
+#  if we are running with xvfb there is no need to run headless; remaining parameters passed to nightwatch configuration
+
+    - name: run test 01_startup_test
       run: |
-        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh
-        
+        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/01_startup_test.js
+
+    - name: run test 02_login_test
+      run: |
+        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/02_login_test.js
+
+    - name: run test 03_model_test
+      run: |
+        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/03_model_test.js
+
+    - name: run test 04_compile_test
+      run: |
+        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/04_compile_test.js
+
+    - name: run test 05_toolbar_test
+      run: |
+        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/05_toolbar_test.js
+
+    - name: run test 06_creating_dsl
+      run: |
+        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/06_creating_dsl.js
+
+    - name: run test 07_transformation_test
+      run: |
+        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/07_transformation_test.js
+
+    - name: run test 08_pacman_transformation_test
+      run: |
+        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/08_pacman_transformation_test.js
+
+    - name: run test 09_missing_files
+      run: |
+        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/09_missing_files.js
+
+    - name: run test 10_undo_test
+      run: |
+        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/10_undo_test.js
+
+    - name: run test 99_ecore_toolbar_test
+      run: |
+        xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh ./tests/99_ecore_toolbar_test.js
+

--- a/.github/workflows/atompm_test.yml
+++ b/.github/workflows/atompm_test.yml
@@ -56,7 +56,6 @@ jobs:
     
     - name: run tests
       run: |
-# if we are running xvfb there is no need to run headless; remaining parameters passed to nightwatch configuration
-#        chromium --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+        chromium --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
         xvfb-run --server-args="-screen 0 2880x1800x24" ./run_tests.sh
         

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -22,8 +22,20 @@ module.exports = {
                 browserName: 'chrome',
                 'goog:chromeOptions': {
                     'args':[
-                        '--window-size=2880,1800',
-                        '--disable-gpu','--remote-debugging-port=9222'
+                        'disable-gpu','remote-debugging-port=9222'
+                    ]
+                }
+            }
+        },
+        run_headless: {
+            launch_url: 'http://localhost:8124/atompm',
+            desiredCapabilities: {
+                browserName: 'chrome',
+                'goog:chromeOptions': {
+                    'args':[
+                        'headless',
+                        'window-size=2880,1800',
+                        'disable-gpu','remote-debugging-port=9222'
                     ]
                 }
             }

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -19,7 +19,13 @@ module.exports = {
         default: {
             launch_url: 'http://localhost:8124/atompm',
             desiredCapabilities: {
-                browserName: 'chrome'
+                browserName: 'chrome',
+                'goog:chromeOptions': {
+                    'args':[
+                        '--window-size=2880,1800',
+                        '--disable-gpu','--remote-debugging-port=9222'
+                    ]
+                }
             }
         }
     },

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -43,7 +43,23 @@ fi
 
 
 echo "Starting tests..."
-./node_modules/nightwatch/bin/nightwatch
+if [ "$#" -ge 1 ]
+then
+    if [ "$1" == "headless" ]
+    then
+        if [ -z "$2" ]
+        then
+            ./node_modules/nightwatch/bin/nightwatch -e run_headless
+        else
+            ./node_modules/nightwatch/bin/nightwatch -e run_headless $2
+        fi
+    else
+        ./node_modules/nightwatch/bin/nightwatch $1
+    fi
+else
+    ./node_modules/nightwatch/bin/nightwatch
+fi
+
 
 echo "Stopping server and mt script..."
 kill "$serverpid"


### PR DESCRIPTION
updated configuration of nightwatch configuration for continuous integration.
- Dropped the use of xvfb as that seemed to be the source of incompatibility
    - it runs properly if it is headless if it has a window size specified, otherwise it also fails as it did with xvfb
- Added the individual tests to the workflow for granularity
- Added command parameters to test script for convenience
   - using the keyword headless allows to run the tests in headless mode
   - passing a specific test file as the last argument for the convenience of not having to launch the servers by hand