### PR TITLE
Add client ID, createSession, joinSession

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -44,16 +44,17 @@
 
 /******************************** GLOBAL VARS *********************************/
 var __user = undefined,
-	 __wid,
-	 __aswid,
-	 __prefs,
-	 __typeToCreate,
-	 __loadedToolbars = {},
-	 __icons = {},
-	 __edges = {},
-	 __canvas,
-	 __saveas;
-	 __option = '',
+	__clientID,
+	__wid,
+	__aswid,
+	__prefs,
+	__typeToCreate,
+	__loadedToolbars = {},
+	__icons = {},
+	__edges = {},
+	__canvas,
+	__saveas,
+	__option = '',
 	 __trafo = '',
 	 __msg = '',
 	 __name = '';

--- a/client/http_utils.js
+++ b/client/http_utils.js
@@ -81,7 +81,7 @@ HttpUtils = function(){
 		return (options & __FORCE_GET ? '/GET' : '')+
 				 (options & __NO_USERNAME ? '' : '/'+__user)+
 	 			 (uri.charAt(0) == '/' ? uri : '/'+uri)+
-	 			 (options & __NO_WID ? '' : '?wid='+wid);
+	 			 (options & __NO_WID ? '' : '?wid='+wid+'&cid='+__clientID);
 	};
 	
 	/**

--- a/client/init.js
+++ b/client/init.js
@@ -42,11 +42,11 @@
 function __initClient()
 {
 	/** PART 1 **/
-	var params = {};
+	let params = {};
 	window.location.search.substring(1).split('&').forEach(
 		function(arg)
 		{	
-			var _arg = arg.split('=');
+			let _arg = arg.split('=');
 			params[_arg[0]] = _arg[1];
 		});
 
@@ -59,6 +59,21 @@ function __initClient()
 
     socket.on('connect',
         function () {
+
+			// request a client ID from the session manager
+			if (__clientID == undefined) {
+				HttpUtils.httpReq(
+					'GET',
+					HttpUtils.url('/newCID', __NO_WID + __NO_USERNAME),
+					undefined,
+					function (statusCode, resp) {
+						if (!utils.isHttpSuccessCode(statusCode))
+							WindowManagement.openDialog(__FATAL_ERROR, 'could not get client ID: error ' + statusCode);
+						else
+							// set the clientID
+							__clientID = resp;
+					});
+			}
 
             if (window.location.search == '' ||
                 ('aswid' in params && 'cswid' in params))

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "minimist": "latest",
         "socket.io": "latest",
-        "socket.io-client": "latest"
+        "socket.io-client": "latest",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "chromedriver": "^102.0.0",
@@ -2470,6 +2471,14 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -4469,6 +4478,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "minimist": "latest",
     "socket.io": "latest",
-    "socket.io-client": "latest"
+    "socket.io-client": "latest",
+    "uuid": "latest"
   },
   "devDependencies": {
     "chromedriver": "^102.0.0",

--- a/session_manager.js
+++ b/session_manager.js
@@ -11,6 +11,7 @@ const logger = require("./logger");
 const _url = require("url");
 const _cp = require("child_process");
 const _path = require("path");
+const _uuid = require("uuid");
 
 /* an array of WebWorkers
 	... each has its own mmmk instance */
@@ -136,8 +137,17 @@ function handle_http_message(url, req, resp){
 
     logger.http("fcn call _ 'message'",{'from': 'server', 'to':"session_mngr"});
 
+    /* create new client ID and return it */
+    if (url.pathname == '/newCID'){
+        let cid = _uuid.v4()
+        _utils.respond(
+            resp,
+            201,
+            '',
+            ''+cid);
+    }
     /* spawn new worker */
-    if( (url.pathname == '/csworker' || url.pathname == '/asworker')
+    else if( (url.pathname == '/csworker' || url.pathname == '/asworker')
         && req.method == 'POST' )
     {
         /* setup and store new worker */


### PR DESCRIPTION
- Client now asks for a client ID from the session manager
- Client ID passed on client HTTP messages
- Client ID used to re-route messages to proper worker
- Created createSession and joinSession commands in session_manager
- Session manager now sets up (most) communication directly between clients and workers

Still some work to do to remove worker ID knowledge in client, and ensure
that client is not setting up any communication in init.js